### PR TITLE
Expected comma between function args

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -408,7 +408,7 @@
 				// until the terminator character `)` or `]` is encountered.
 				// e.g. `foo(bar, baz)`, `my_func()`, or `[bar, baz]`
 				gobbleArguments = function(termination) {
-					var ch_i, args = [], node;
+					var ch_i, args = [], ncommas = 0, node;
 					while(index < length) {
 						gobbleSpaces();
 						ch_i = exprICode(index);
@@ -417,6 +417,9 @@
 							break;
 						} else if (ch_i === COMMA_CODE) { // between expressions
 							index++;
+							ncommas++;
+						} else if (ch_i !== COMMA_CODE && args.length > ncommas) { 
+							throwError('Expected comma', index);
 						} else {
 							node = gobbleExpression();
 							if(!node || node.type === COMPOUND) {


### PR DESCRIPTION
foo(1.3.1) parsed as 2 argument call with 1.3 and 0.1 args, this is a quick fix of that.
