### PR TITLE
json5 support: ObjectExpression and Property nodes

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -83,6 +83,28 @@ test('Arrays', function() {
 	});
 });
 
+test('JSON Expressions', function() {
+	test_parser("{}", {type: "ObjectExpression", properties: []});
+
+	test_parser('{ "foo": 3 }', {
+		type: "ObjectExpression",
+		properties: [
+			{
+				type: "Property",
+				key: {
+					type: "Literal",
+					value: "foo",
+					raw: "\"foo\""
+				},
+				value: {
+					type: "Literal",
+					value: 3
+				}
+			}
+		]
+	});
+});
+
 test('Ops', function() {
 	test_op_expession("1");
 	test_op_expession("1+2");


### PR DESCRIPTION
Hi there,

I needed to be able to use jsons in the middle of the evaluated expressions.
I added support for esprima's ObjectExpression and Property nodes; 
json, json5 property names and values can be expressions are correctly parsed.
For example: `{ ("foo"+1): DATE(3), "oh": { nested: [ 1, 2+3, 3 ] } }` will generate properly.

Thanks for a very nice and small parser!
