### PR TITLE
Update max_unop_len when adding unary operators

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -554,6 +554,7 @@
 	 * @return jsep
 	 */
 	jsep.addUnaryOp = function(op_name) {
+		max_unop_len = Math.max(op_name.length, max_unop_len);
 		unary_ops[op_name] = t; return this;
 	};
 


### PR DESCRIPTION
Set `max_unop_len` to the maximum unary operator length when adding new unary operators via `jsep.addUnaryOp()`.
