### PR TITLE
Allow escaping of backslash.

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -350,6 +350,7 @@
 								case 'b': str += '\b'; break;
 								case 'f': str += '\f'; break;
 								case 'v': str += '\x0B'; break;
+								case '\\': str += '\\'; break;
 							}
 						} else {
 							str += ch;


### PR DESCRIPTION
'Level1\\Level2' turns into 'Level1Level2'.
This fix allows using a \ in a string literal.
