### PR TITLE
Update tsd.d.ts

### DIFF
--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,66 +1,90 @@
-
 declare module 'jsep' {
 
-  namespace jsep {
-    export interface IExpression {
-      type: string;
+    namespace jsep {
+        export interface Expression {
+            type: ExpressionType;
+        }
+
+        export interface ArrayExpression extends Expression {
+            type: 'ArrayExpression';
+            elements: Expression[];
+        }
+
+        export interface BinaryExpression extends Expression {
+            type: 'BinaryExpression';
+            operator: string;
+            left: Expression;
+            right: Expression;
+        }
+
+        export interface CallExpression extends Expression {
+            type: 'CallExpression';
+            arguments: Expression[];
+            callee: Expression;
+        }
+
+        export interface Compound extends Expression {
+            type: 'Compound';
+            body: Expression[];
+        }
+
+        export interface ConditionalExpression extends Expression {
+            type: 'ConditionalExpression';
+            test: Expression;
+            consequent: Expression;
+            alternate: Expression;
+        }
+
+        export interface Identifier extends Expression {
+            type: 'Identifier';
+            name: string;
+        }
+
+        export interface Literal extends Expression {
+            type: 'Literal';
+            value: boolean | number | string;
+            raw: string;
+        }
+
+        export interface LogicalExpression extends Expression {
+            type: 'LogicalExpression';
+            operator: string;
+            left: Expression;
+            right: Expression;
+        }
+
+        export interface MemberExpression extends Expression {
+            type: 'MemberExpression';
+            computed: boolean;
+            object: Expression;
+            property: Expression;
+        }
+
+        export interface ThisExpression extends Expression {
+            type: 'ThisExpression';
+        }
+
+        export interface UnaryExpression extends Expression {
+            type: 'UnaryExpression';
+            operator: string;
+            argument: Expression;
+            prefix: boolean;
+        }
+
+        type ExpressionType = 'Compound' | 'Identifier' | 'MemberExpression' | 'Literal' | 'ThisExpression' | 'CallExpression' | 'UnaryExpression' | 'BinaryExpression' | 'LogicalExpression' | 'ConditionalExpression' | 'ArrayExpression';
+
+        function addBinaryOp(operatorName: string, precedence: number): void;
+
+        function addUnaryOp(operatorName: string): void;
+
+        function removeBinaryOp(operatorName: string): void;
+
+        function removeUnaryOp(operatorName: string): void;
+
+        const version: string;
     }
 
-    export interface ILiteral extends IExpression {
-      type: 'Literal';
-      value: any;
-      raw: string;
-    }
+    function jsep(val: string | jsep.Expression): jsep.Expression;
 
-    export interface IIdentifier extends IExpression {
-      type: 'Identifier'
-      name: string;
-    }
-
-    export interface IBinaryExpression extends IExpression {
-      type: 'BinaryExpression';
-      operator: string;
-      left: IExpression;
-      right: IExpression;
-    }
-
-    export interface IUnaryExpression extends IExpression {
-      type: 'UnaryExpression';
-      operator: string;
-      argument: IExpression;
-      prefix: boolean;
-    }
-
-    export interface IMemberExpression extends IExpression {
-      type: 'MemberExpression';
-      computed: boolean;
-      object: IExpression;
-      property: IExpression;
-    }
-
-    export interface ICallExpression extends IExpression {
-      type: 'CallExpression';
-      arguments: IExpression[];
-      callee: IExpression;
-    }
-
-    export interface IConditionalExpression extends IExpression {
-      type: 'ConditionalExpression';
-      test: IExpression;
-      consequent: IExpression;
-      alternate: IExpression;
-    }
-
-    export function addBinaryOp(operatorSymbol: string, precedence: number);
-
-    export function addUnaryOp(operatorSymbol: string);
-
-    export function removeBinaryOp(operatorSymbol: string);
-
-    export function removeUnaryOp(operatorSymbol: string);
-  }
-
-  function jsep(obj: string | jsep.IExpression): jsep.IExpression;
-
-  export = jsep;
+    export = jsep;
 }


### PR DESCRIPTION
This is the d.ts I've been using in production.
- fills in missing expression types (ArrayExpression, ThisExpression, etc...)
- types `Expression.type`
- doesn't use interface `I` prefix (it's not a standard used in the community)