### PR TITLE
Fix identifiers as custom ops

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -178,7 +178,13 @@
 					gobbleSpaces();
 					var biop, to_check = expr.substr(index, max_binop_len), tc_len = to_check.length;
 					while(tc_len > 0) {
-						if(binary_ops.hasOwnProperty(to_check)) {
+						// Don't accept a binary op when it is an identifier.
+						// Binary ops that start with a identifier-valid character must be followed
+						// by a non identifier-part valid character
+						if(binary_ops.hasOwnProperty(to_check) && (
+							!isIdentifierStart(exprICode(index)) ||
+							(index+to_check.length< expr.length && !isIdentifierPart(exprICode(index+to_check.length)))
+						)) {
 							index += tc_len;
 							return to_check;
 						}
@@ -283,7 +289,7 @@
 							return gobbleVariable();
 						}
 					}
-					
+
 					return false;
 				},
 				// Parse simple numeric literals: `12`, `3.4`, `.5`. Do this by using a string to

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -272,7 +272,13 @@
 						to_check = expr.substr(index, max_unop_len);
 						tc_len = to_check.length;
 						while(tc_len > 0) {
-							if(unary_ops.hasOwnProperty(to_check)) {
+						// Don't accept an unary op when it is an identifier.
+						// Unary ops that start with a identifier-valid character must be followed
+						// by a non identifier-part valid character
+							if(unary_ops.hasOwnProperty(to_check) && (
+								!isIdentifierStart(exprICode(index)) ||
+								(index+to_check.length < expr.length && !isIdentifierPart(exprICode(index+to_check.length)))
+							)) {
 								index += tc_len;
 								return {
 									type: UNARY_EXP,

--- a/test/tests.js
+++ b/test/tests.js
@@ -106,6 +106,25 @@ test('Custom operators', function() {
         right: {name: 'b'}
     });
 
+	jsep.addBinaryOp("or", 1);
+	test_parser("oneWord ordering anotherWord", {
+		type: 'Compound',
+		body: [
+			{
+				type: 'Identifier',
+				name: 'oneWord'
+			},
+			{
+				type: 'Identifier',
+				name: 'ordering'
+			},
+			{
+				type: 'Identifier',
+				name: 'anotherWord'
+			}
+		]
+    });
+
 	jsep.addUnaryOp("#");
 	test_parser("#a", {
 		type: "UnaryExpression",

--- a/test/tests.js
+++ b/test/tests.js
@@ -131,6 +131,19 @@ test('Custom operators', function() {
 		operator: "#",
 		argument: {type: "Identifier", name: "a"}
 	});
+
+	jsep.addUnaryOp("not");
+	test_parser("not a", {
+		type: "UnaryExpression",
+		operator: "not",
+		argument: {type: "Identifier", name: "a"}
+	});
+
+	jsep.addUnaryOp("notes");
+	test_parser("notes", {
+		type: "Identifier",
+		name: "notes"
+	});
 });
 
 test('Custom alphanumeric operators', function() {


### PR DESCRIPTION
Fixes https://github.com/soney/jsep/issues/68

As @LeaVerou point out in https://github.com/soney/jsep/pull/27 custom operators are overriding valid identifiers.

For example, I expect this 
```
        jsep.addUnaryOp("notes");
	test_parser("notes", {
		type: "Identifier",
		name: "notes"
	})
```
instead of returning `{type: "UnaryExpression", operator: "not", argument: {…}, prefix: true}`, which is the current behavior.

The same problem arises when a custom binary operation is added.

This PR changes the criteria to accept an operator, making it stricter. In particular, it won't accept operators when they start with an identifier-start valid character and they are not followed by an identifier-part invalid character.