### PR TITLE
Throw on missing function arguments

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -431,15 +431,23 @@
 				// e.g. `foo(bar, baz)`, `my_func()`, or `[bar, baz]`
 				gobbleArguments = function(termination) {
 					var ch_i, args = [], node, closed = false;
+					var separator_count = 0;
 					while(index < length) {
 						gobbleSpaces();
 						ch_i = exprICode(index);
 						if(ch_i === termination) { // done parsing
 							closed = true;
 							index++;
+							if(separator_count && separator_count >= args.length){
+								throwError('Unexpected token ' + String.fromCharCode(termination), index);
+							}
 							break;
 						} else if (ch_i === COMMA_CODE) { // between expressions
 							index++;
+							separator_count++;
+							if(separator_count !== args.length) { // missing argument
+								throwError('Unexpected token ,', index);
+							}
 						} else {
 							node = gobbleExpression();
 							if(!node || node.type === COMPOUND) {

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -438,7 +438,7 @@
 						if(ch_i === termination) { // done parsing
 							closed = true;
 							index++;
-							if(separator_count && separator_count >= args.length){
+							if(termination === CPAREN_CODE && separator_count && separator_count >= args.length){
 								throwError('Unexpected token ' + String.fromCharCode(termination), index);
 							}
 							break;
@@ -446,7 +446,14 @@
 							index++;
 							separator_count++;
 							if(separator_count !== args.length) { // missing argument
-								throwError('Unexpected token ,', index);
+								if(termination === CPAREN_CODE) {
+									throwError('Unexpected token ,', index);
+								}
+								else if(termination === CBRACK_CODE) {
+									for(var arg = args.length; arg< separator_count; arg++) {
+										args.push(null);
+									}
+								}
 							}
 						} else {
 							node = gobbleExpression();

--- a/test/tests.js
+++ b/test/tests.js
@@ -206,6 +206,8 @@ test('Uncompleted expression-call/array', function() {
 
 test('Esprima Comparison', function() {
 	([
+		"[1,,3]",
+		"[1,,]", // this is actually incorrect in esprima
 		" true",
 		"false ",
 		" 1.2 ",

--- a/test/tests.js
+++ b/test/tests.js
@@ -176,6 +176,21 @@ test('Bad Numbers', function() {
 	});
 });
 
+test('Missing arguments', function() {
+	throws(function(){
+		var x = jsep("check(,)");
+	}, "detects missing argument (all)");
+	throws(function(){
+		var x = jsep("check(,1,2)");
+	}, "detects missing argument (head)");
+	throws(function(){
+		var x = jsep("check(1,,2)");
+	}, "detects missing argument (intervening)");
+	throws(function(){
+		var x = jsep("check(1,2,)");
+	}, "detects missing argument (tail)");
+});
+
 test('Uncompleted expression-call/array', function() {
 	throws(function(){
 		var x = jsep("myFunction(a,b");


### PR DESCRIPTION
In #93 I noted that JSEP ignored missing function arguments. This code will throw in that case (see test for examples).

What I did not realize at the time was that arrays with missing elements were also broken, in the same code path. This PR fixes that as well, so 

`[1,,2]` returns `[1, null, 2]` (`null` is what esprima inserts in this case; I would prefer `undefined`, but I'm trying to keep it consistent). 

Finally I noticed that esprima is actually incorrect in the case of a trailing, missing array entry, so 
`[1,,]` in esprima returns `[1,null]` (a single trailing null) instead of the expected `[1,null,null]`. This could be fixed but I opted here to just replicate the esprima behavior. (Also FWIW those two arrays are functionally equivalent).

