### PR TITLE
fix backslash removed from string literal

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -367,7 +367,7 @@
 								case 'b': str += '\b'; break;
 								case 'f': str += '\f'; break;
 								case 'v': str += '\x0B'; break;
-								default : str += ch;
+								default : str += '\\' + ch;
 							}
 						} else {
 							str += ch;


### PR DESCRIPTION
Parsing a string Literal, if a backslash is detected and the following character is not a valid escape code, the backslash is **removed** from the string.
This doesn't allow to do checks with a backslash inside a Literal, such as:
```
Identifier == 'hello\world'
```
because the parsed Literal value will become **helloworld**

```
{
    type: 'BinaryExpression'
    operator: '=='
    left: {
        type: 'Identifier'
        name: 'Identifier'
    }
    right: {
        type: 'Literal'
        value: 'helloworld'
        raw: ''helloworld''
    } 
}
```
With this fix I'll keep the character if the backslash is not used as an escape code.