### PR TITLE
Fix gobbleGroup not working with sequence expressions, i.e. "(1, 2)"

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -167,7 +167,7 @@ let jsep = function(expr) {
 					// the expression passed in probably has too much
 				}
 				else if (index < length) {
-					if (untilICode && ch_i === untilICode) {
+					if (ch_i === untilICode) {
 						break;
 					}
 					throwError('Unexpected "' + exprI(index) + '"', index);
@@ -631,6 +631,9 @@ let jsep = function(expr) {
 			index++;
 			if (nodes.length === 1) {
 				return nodes[0];
+			}
+			else if (!nodes.length) {
+				return false;
 			}
 			else {
 				return {

--- a/test/tests.js
+++ b/test/tests.js
@@ -237,6 +237,7 @@ QUnit.test('Esprima Comparison', function(assert) {
 		"(1,2)",
 		"(a, a + b > 2)",
 		"a((1 + 2), (e > 0 ? f : g))",
+		"(((1)))",
 		"(Object.variable.toLowerCase()).length == 3",
 		"(Object.variable.toLowerCase())  .  length == 3",
 		"[1] + [2]"

--- a/test/tests.js
+++ b/test/tests.js
@@ -235,6 +235,8 @@ QUnit.test('Esprima Comparison', function(assert) {
 		"$foo[ bar][ baz]    (a, bb ,   c  )   .other12 ['lawl'][12]",
 		"(a(b(c[!d]).e).f+'hi'==2) === true",
 		"(1,2)",
+		"(a, a + b > 2)",
+		"a((1 + 2), (e > 0 ? f : g))",
 		"(Object.variable.toLowerCase()).length == 3",
 		"(Object.variable.toLowerCase())  .  length == 3",
 		"[1] + [2]"

--- a/test/tests.js
+++ b/test/tests.js
@@ -234,6 +234,7 @@ QUnit.test('Esprima Comparison', function(assert) {
 		"$foo     [ 12	] [ baz[z]    ].other12*4 + 1 ",
 		"$foo[ bar][ baz]    (a, bb ,   c  )   .other12 ['lawl'][12]",
 		"(a(b(c[!d]).e).f+'hi'==2) === true",
+		"(1,2)",
 		"(Object.variable.toLowerCase()).length == 3",
 		"(Object.variable.toLowerCase())  .  length == 3",
 		"[1] + [2]"


### PR DESCRIPTION
- make the expressions[] parsing a separate function so it can be reused
- instead of parsing a single expression, let it parse multiple expressions
- Add test to compare against eprisma, which uses 'SequenceExpression' instead of 'Compound' in that case

Fixes #92 

(it also allows for future arrow-function support, versus the code/comment from [this PR](https://github.com/EricSmekens/jsep/pull/123/files#r611125953) )