### PR TITLE
Some common fixes before adding other plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export interface HookScope {
 #### How to add plugins:
 ```javascript
 import { Jsep } from 'jsep';
-import 'jsep/plugins/ternary';
+import 'jsep/plugins/ternary.js';
 ```
 
 #### Optional Plugins:

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // Add default plugins:
 import jsep from './jsep.js';
-import './plugins/ternary/ternary.js';
+import './plugins/ternary.js';
 
 export * from './jsep.js';
 export default jsep;

--- a/src/plugins/ternary.js
+++ b/src/plugins/ternary.js
@@ -1,4 +1,4 @@
-import {Jsep} from '../../jsep.js';
+import {Jsep} from '../jsep.js';
 
 // Ternary expression: test ? consequent : alternate
 Jsep.hooksAdd('after-expression', function gobbleTernary(env) {

--- a/test/plugins/ternary.test.js
+++ b/test/plugins/ternary.test.js
@@ -1,4 +1,4 @@
-import '../../src/plugins/ternary/ternary.js';
+import '../../src/plugins/ternary.js';
 import {testParser, esprimaComparisonTest} from '../test_utils.js';
 
 const { test } = QUnit;

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -35,7 +35,7 @@ export function filterProps(larger, smaller) {
 	const rv = (typeof larger.length === 'number') ? [] : {};
 	for (let propName in smaller) {
 		let propVal = smaller[propName];
-		if (typeof propVal === 'string' || typeof propVal === 'number') {
+		if (typeof propVal === 'string' || typeof propVal === 'number' || typeof propVal === 'boolean' || propVal === null) {
 			rv[propName] = larger[propName];
 		}
 		else {


### PR DESCRIPTION
- Remove nested ternary plugin folder (was originally thinking of having test files next to source)
- Tests now restore original operation after running to avoid polluting other tests (since they modify static values versus instance values)
- `filterProps` test utility now handles bool and null properly