### PR TITLE
Spread Operator Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Plugins are registered by calling `jsep.plugins.register()` with the plugin(s) a
 #### JSEP-provided plugins:
 * `jsepTernary`: Built-in by default, adds support for ternary `a ? b : c` expressions
 * `jsepObject`: Adds object expression support: `{ a: 1, b: { c }}`
+* `jsepSpread`: Adds support for the spread operator, `fn(...[1, ...a])`. Works with `jsepObject` plugin, too
 
 #### How to add plugins:
 Plugins have a `name` property so that they can only be registered once.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,6 +69,7 @@ export default [
 	},
 	...[
 		'jsepObject',
+		'jsepSpread',
 	].map(name => ({
 		input: `src/plugins/${name}.js`,
 		output: [

--- a/src/plugins/jsepSpread.js
+++ b/src/plugins/jsepSpread.js
@@ -1,0 +1,18 @@
+export default {
+	name: 'jsepSpread',
+
+	init(jsep) {
+		// Spread operator: ...a
+		// Works in objects { ...a }, arrays [...a], function args fn(...a)
+		// NOTE: does not prevent `a ? ...b : ...c` or `...123`
+		jsep.hooksAdd('gobble-token', function gobbleSpread(env) {
+			if ([0, 1, 2].every(i => this.expr.charCodeAt(this.index + i) === jsep.PERIOD_CODE) && !env.node) {
+				this.index += 3;
+				env.node = {
+					type: 'SpreadElement',
+					argument: this.gobbleExpression(),
+				};
+			}
+		});
+	},
+};

--- a/test/plugins/jsepSpread.test.js
+++ b/test/plugins/jsepSpread.test.js
@@ -1,0 +1,69 @@
+import jsep from '../../src/index.js';
+import spread from '../../src/plugins/jsepSpread.js';
+import {resetJsepHooks, testParser} from '../test_utils.js';
+
+const { test } = QUnit;
+
+(function () {
+	QUnit.module('Plugin:Spread', (qunit) => {
+		qunit.before(() => jsep.plugins.register(spread));
+		qunit.after(resetJsepHooks);
+
+		test('should parse array spread', (assert) => {
+			testParser('[...a]', {
+				type: 'ArrayExpression',
+				elements: [
+					{
+						type: 'SpreadElement',
+						argument: {
+							type: 'Identifier',
+							'name': 'a',
+						},
+					},
+				]
+			}, assert);
+		});
+
+		test('should parse function spread', (assert) => {
+			testParser('fn(1, ...b)', {
+				type: 'CallExpression',
+				arguments: [
+					{
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					},
+					{
+						type: 'SpreadElement',
+						argument: {
+							type: 'Identifier',
+							name: 'b'
+						}
+					}
+				],
+				callee: {
+					type: 'Identifier',
+					name: 'fn'
+				}
+			}, assert);
+		});
+
+		test('should not throw any errors', (assert) => {
+			[
+				'fn(...123)', // NOTE: invalid iterator is not checked by jsep (same for [....4] = ... 0.4)
+				'fn(..."abc")',
+				'[1, ...[2, 3]]',
+				'[1, ...(a ? b : c)]',
+			].forEach(expr => testParser(expr, {}, assert));
+		});
+
+		test('should give an error for invalid expressions', (assert) => {
+			[
+				// '[a ? ...b : ...c]', // is invalid JS, should be `...(a ? b : c)`, but jsep doesn't error
+				'[.....5]', // extra ..
+				'[..2]', // missing .
+				'[...3', // missing ]
+			].forEach(expr => assert.throws(() => jsep(expr)));
+		});
+	});
+}());

--- a/test/tests.js
+++ b/test/tests.js
@@ -4,3 +4,4 @@ export * from './hooks.test.js';
 export * from './plugins.test.js';
 export * from './plugins/jsepTernary.test.js';
 export * from './plugins/jsepObject.test.js';
+export * from './plugins/jsepSpread.test.js';


### PR DESCRIPTION
- works in objects { ...a }, arrays [...a], function args fn(...a)
- NOTE: does not prevent `a ? ...b : ...c` or `...123`