### PR TITLE
Arrow Function plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Plugins are registered by calling `jsep.plugins.register()` with the plugin(s) a
 
 #### JSEP-provided plugins:
 * `jsepTernary`: Built-in by default, adds support for ternary `a ? b : c` expressions
+* `jsepArrow`: Adds arrow-function support: `v => !!v`
 * `jsepObject`: Adds object expression support: `{ a: 1, b: { c }}`
 
 #### How to add plugins:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -68,6 +68,7 @@ export default [
 		],
 	},
 	...[
+		'jsepArrow',
 		'jsepObject',
 	].map(name => ({
 		input: `src/plugins/${name}.js`,

--- a/src/plugins/jsepArrow.js
+++ b/src/plugins/jsepArrow.js
@@ -1,0 +1,22 @@
+const ARROW_EXP = 'ArrowFunctionExpression';
+
+export default {
+	name: 'jsepArrow',
+
+	init(jsep) {
+		// arrow-function expressions: () => x, v => v, (a, b) => v
+		jsep.addBinaryOp('=>', 0);
+		jsep.hooks.add('after-expression', function fixBinaryArrow(env) {
+			if (env.node && env.node.operator === '=>') {
+				env.node = {
+					type: ARROW_EXP,
+					params: env.node.left ? [env.node.left] : null,
+					body: env.node.right,
+				};
+				if (env.node.params && env.node.params[0].type === jsep.SEQUENCE_EXP) {
+					env.node.params = env.node.params[0].expressions;
+				}
+			}
+		});
+	}
+};

--- a/test/plugins/jsepArrow.test.js
+++ b/test/plugins/jsepArrow.test.js
@@ -1,16 +1,13 @@
 import jsep from '../../src/index.js';
 import arrow from '../../src/plugins/jsepArrow.js';
-import { testParser, resetJsepHooks } from '../test_utils.js';
+import { testParser, resetJsepDefaults } from '../test_utils.js';
 
 const { test } = QUnit;
 
 (function () {
 	QUnit.module('Plugin:Arrow Function', (qunit) => {
 		qunit.before(() => jsep.plugins.register(arrow));
-		qunit.after(() => {
-			jsep.removeBinaryOp('=>');
-			resetJsepHooks();
-		});
+		qunit.after(resetJsepDefaults);
 
 		test('should parse basic arrow expression with no args, () =>', (assert) => {
 			testParser('a.find(() => true)', {

--- a/test/plugins/jsepArrow.test.js
+++ b/test/plugins/jsepArrow.test.js
@@ -1,0 +1,154 @@
+import jsep from '../../src/index.js';
+import arrow from '../../src/plugins/jsepArrow.js';
+import { testParser, resetJsepHooks } from '../test_utils.js';
+
+const { test } = QUnit;
+
+(function () {
+	QUnit.module('Plugin:Arrow Function', (qunit) => {
+		qunit.before(() => jsep.plugins.register(arrow));
+		qunit.after(() => {
+			jsep.removeBinaryOp('=>');
+			resetJsepHooks();
+		});
+
+		test('should parse basic arrow expression with no args, () =>', (assert) => {
+			testParser('a.find(() => true)', {
+				type: "CallExpression",
+				arguments: [
+					{
+						type: "ArrowFunctionExpression",
+						params: null,
+						body: {
+							type: "Literal",
+							value: true,
+							raw: "true"
+						}
+					}
+				],
+				callee: {
+					type: "MemberExpression",
+					computed: false,
+					object: {
+						type: "Identifier",
+						name: "a"
+					},
+					property: {
+						type: "Identifier",
+						name: "find"
+					}
+				}
+			}, assert);
+		});
+
+		test('should parse basic arrow expression with single non-parenthesized arg, v =>', (assert) => {
+			testParser('[1, 2].find(v => v === 2)', {
+				type: "CallExpression",
+				arguments: [
+					{
+						type: "ArrowFunctionExpression",
+						params: [
+							{
+								type: "Identifier",
+								name: "v"
+							}
+						],
+						body: {
+							type: "BinaryExpression",
+							operator: "===",
+							left: {
+								type: "Identifier",
+								name: "v"
+							},
+							right: {
+								type: "Literal",
+								value: 2,
+								raw: "2"
+							}
+						}
+					}
+				],
+				callee: {
+					type: "MemberExpression",
+					computed: false,
+					object: {
+						type: "ArrayExpression",
+						elements: [
+							{
+								type: "Literal",
+								value: 1,
+								raw: "1"
+							},
+							{
+								type: "Literal",
+								value: 2,
+								raw: "2"
+							}
+						]
+					},
+					property: {
+						type: "Identifier",
+						name: "find"
+					}
+				}
+			}, assert);
+		});
+
+		test('should parse basic arrow expression with multiple arga, (a, b) =>', (assert) => {
+			testParser('a.find((val, key) => key === "abc")', {
+				type: "CallExpression",
+				arguments: [
+					{
+						type: "ArrowFunctionExpression",
+						params: [
+							{
+								type: "Identifier",
+								name: "val"
+							},
+							{
+								type: "Identifier",
+								name: "key"
+							}
+						],
+						body: {
+							type: "BinaryExpression",
+							operator: "===",
+							left: {
+								type: "Identifier",
+								name: "key"
+							},
+							right: {
+								type: "Literal",
+								value: "abc",
+								raw: "\"abc\""
+							}
+						}
+					}
+				],
+				callee: {
+					type: "MemberExpression",
+					computed: false,
+					object: {
+						type: "Identifier",
+						name: "a"
+					},
+					property: {
+						type: "Identifier",
+						name: "find"
+					}
+				}
+			}, assert);
+		});
+
+		[
+			'(["a", "b"].find(v => v === "b").length > 1 || 2) === true',
+			'a.find(val => key === "abc")',
+			'a.find(() => []).length > 2',
+			'(a || b).find(v => v(1))',
+		].forEach(expr => {
+			test(`should parse expr "${expr}" without error`, (assert) => {
+				testParser(expr, {}, assert);
+			});
+		});
+	});
+}());

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,5 +2,6 @@
 export * from './jsep.test.js';
 export * from './hooks.test.js';
 export * from './plugins.test.js';
+export * from './plugins/jsepArrow.test.js';
 export * from './plugins/jsepTernary.test.js';
 export * from './plugins/jsepObject.test.js';


### PR DESCRIPTION
() => x
x => x
(a, b) => x

Treats '=>' as a binary operator, but replaces the binary expression with the correct node type afterward