### PR TITLE
Cleaning up plugin-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Plugins are registered by calling `jsep.plugins.register()` with the plugin(s) a
 * `jsepComment`: Adds support for ignoring comments: `a /* ignore this */ > 1 // ignore this too`
 * `jsepNew`: Adds 'new' keyword support: `new Date()`
 * `jsepObject`: Adds object expression support: `{ a: 1, b: { c }}`
+* `jsepRegex`: Adds support for regular expression literals: `/[a-z]{2}/ig`
 * `jsepSpread`: Adds support for the spread operator, `fn(...[1, ...a])`. Works with `jsepObject` plugin, too
 * `jsepTemplateLiteral`: Adds template literal support: `` `hi ${name}` ``
 
@@ -163,7 +164,8 @@ export interface HookScope {
     gobbleExpression: () => Expression;
     gobbleBinaryOp: () => PossibleExpression;
     gobbleBinaryExpression: () => PossibleExpression;
-    gobbleToken: () =>  PossibleExpression;
+    gobbleToken: () => PossibleExpression;
+    gobbleTokenProperty: (Expression) => Expression;
     gobbleNumericLiteral: () => PossibleExpression;
     gobbleStringLiteral: () => PossibleExpression;
     gobbleIdentifier: () => PossibleExpression;

--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ the `node` property as needed.
 ```typescript
 export interface HookScope {
     index: number;
-    expr: string;
-    char: string; // current character of the expression
-    code: number; // current character code of the expression
+    readonly expr: string;
+    readonly char: string; // current character of the expression
+    readonly code: number; // current character code of the expression
     gobbleSpaces: () => void;
-    gobbleExpressions: (number?) => Eexpression[];
+    gobbleExpressions: (number?) => Expression[];
     gobbleExpression: () => Expression;
     gobbleBinaryOp: () => PossibleExpression;
     gobbleBinaryExpression: () => PossibleExpression;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,6 +71,7 @@ export default [
 		'jsepComment',
 		'jsepNew',
 		'jsepObject',
+		'jsepRegex',
 		'jsepSpread',
 		'jsepTemplateLiteral',
 	].map(name => ({

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,3 +1,6 @@
+/**
+ * @implements {IHooks}
+ */
 export default class Hooks {
 	/**
 	 * @callback HookCallback

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -838,7 +838,6 @@ export class Jsep {
 const hooks = new Hooks();
 Object.assign(Jsep, {
 	hooks,
-	hooksAdd: hooks.add.bind(hooks),
 	plugins: new Plugins(Jsep),
 
 	// Node Types

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -524,15 +524,22 @@ export class Jsep {
 			return this.runHook('after-token', false);
 		}
 
+		node = this.gobbleTokenProperty(node);
+		return this.runHook('after-token', node);
+	}
+
+	/**
+	 * Gobble properties of of identifiers/strings/arrays/groups.
+	 * e.g. `foo`, `bar.baz`, `foo['bar'].baz`
+	 * It also gobbles function calls:
+	 * e.g. `Math.acos(obj.angle)`
+	 * @param {jsep.Expression} node
+	 * @returns {jsep.Expression}
+	 */
+	gobbleTokenProperty(node) {
 		this.gobbleSpaces();
 
-		ch = this.code;
-
-		// Gobble properties of of identifiers/strings/arrays/groups.
-		// e.g. `foo`, `bar.baz`, `foo['bar'].baz`
-		// It also gobbles function calls:
-		// e.g. `Math.acos(obj.angle)`
-
+		let ch = this.code;
 		while (ch === Jsep.PERIOD_CODE || ch === Jsep.OBRACK_CODE || ch === Jsep.OPAREN_CODE) {
 			this.index++;
 
@@ -571,7 +578,7 @@ export class Jsep {
 			ch = this.code;
 		}
 
-		return this.runHook('after-token', node);
+		return node;
 	}
 
 	/**

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,3 +1,6 @@
+/**
+ * @implements {IPlugins}
+ */
 export default class Plugins {
 	constructor(jsep) {
 		this.jsep = jsep;

--- a/src/plugins/jsepObject.js
+++ b/src/plugins/jsepObject.js
@@ -11,7 +11,7 @@ export default {
 
 		// Object literal support
 		function gobbleObjectExpression(env) {
-			if (this.code === OCURLY_CODE && !env.node) {
+			if (this.code === OCURLY_CODE) {
 				this.index++;
 				const properties = this.gobbleArguments(CCURLY_CODE)
 					.map((arg) => {

--- a/src/plugins/jsepObject.js
+++ b/src/plugins/jsepObject.js
@@ -44,7 +44,7 @@ export default {
 				};
 			}
 		}
-		jsep.hooksAdd('gobble-expression', gobbleObjectExpression);
-		jsep.hooksAdd('after-token', gobbleObjectExpression);
+		jsep.hooks.add('gobble-expression', gobbleObjectExpression);
+		jsep.hooks.add('after-token', gobbleObjectExpression);
 	}
 };

--- a/src/plugins/jsepRegex.js
+++ b/src/plugins/jsepRegex.js
@@ -1,0 +1,53 @@
+const FSLASH_CODE = 47; // '/'
+
+export default {
+	name: 'jsepRegex',
+
+	init(jsep) {
+		// Regex literal: /abc123/ig
+		jsep.hooks.add('gobble-token', function gobbleRegexLiteral(env) {
+			if (this.code === FSLASH_CODE) {
+				const patternIndex = ++this.index;
+
+				while (this.index < this.expr.length) {
+					if (this.char === '/') {
+						const pattern = this.expr.slice(patternIndex, this.index);
+
+						let flags = '';
+						while (++this.index < this.expr.length) {
+							const code = this.code;
+							if ((code >= 97 && code <= 122) // a...z
+								|| (code >= 65 && code <= 90) // A...Z
+								|| (code >= 48 && code <= 57)) { // 0-9
+								flags += this.char;
+							}
+							else {
+								break;
+							}
+						}
+
+						let value;
+						try {
+							value = new RegExp(pattern, flags);
+						}
+						catch (e) {
+							this.throwError(e.message);
+						}
+
+						env.node = {
+							type: jsep.LITERAL,
+							value,
+							raw: this.expr.slice(patternIndex - 1, this.index),
+						};
+
+						// allow . [] and () after regex: /regex/.test(a)
+						env.node = this.gobbleTokenProperty(env.node);
+						return env.node;
+					}
+					this.index += 1;
+				}
+				this.throwError('Unclosed Regex');
+			}
+		});
+	},
+};

--- a/src/plugins/jsepSpread.js
+++ b/src/plugins/jsepSpread.js
@@ -5,7 +5,7 @@ export default {
 		// Spread operator: ...a
 		// Works in objects { ...a }, arrays [...a], function args fn(...a)
 		// NOTE: does not prevent `a ? ...b : ...c` or `...123`
-		jsep.hooksAdd('gobble-token', function gobbleSpread(env) {
+		jsep.hooks.add('gobble-token', function gobbleSpread(env) {
 			if ([0, 1, 2].every(i => this.expr.charCodeAt(this.index + i) === jsep.PERIOD_CODE) && !env.node) {
 				this.index += 3;
 				env.node = {

--- a/src/plugins/jsepSpread.js
+++ b/src/plugins/jsepSpread.js
@@ -6,7 +6,7 @@ export default {
 		// Works in objects { ...a }, arrays [...a], function args fn(...a)
 		// NOTE: does not prevent `a ? ...b : ...c` or `...123`
 		jsep.hooks.add('gobble-token', function gobbleSpread(env) {
-			if ([0, 1, 2].every(i => this.expr.charCodeAt(this.index + i) === jsep.PERIOD_CODE) && !env.node) {
+			if ([0, 1, 2].every(i => this.expr.charCodeAt(this.index + i) === jsep.PERIOD_CODE)) {
 				this.index += 3;
 				env.node = {
 					type: 'SpreadElement',

--- a/src/plugins/jsepTernary.js
+++ b/src/plugins/jsepTernary.js
@@ -5,7 +5,7 @@ export default {
 
 	init(jsep) {
 		// Ternary expression: test ? consequent : alternate
-		jsep.hooksAdd('after-expression', function gobbleTernary(env) {
+		jsep.hooks.add('after-expression', function gobbleTernary(env) {
 			if (this.code === jsep.QUMARK_CODE) {
 				this.index++;
 				const test = env.node;

--- a/test/plugins/jsepComment.test.js
+++ b/test/plugins/jsepComment.test.js
@@ -1,13 +1,13 @@
 import jsep from '../../src/index.js';
 import comment from '../../src/plugins/jsepComment.js';
-import { testParser, resetJsepHooks } from '../test_utils.js';
+import { testParser, resetJsepDefaults } from '../test_utils.js';
 
 const { test } = QUnit;
 
 (function () {
 	QUnit.module('Plugin:Comment', (qunit) => {
 		qunit.before(() => jsep.plugins.register(comment));
-		qunit.after(resetJsepHooks);
+		qunit.after(resetJsepDefaults);
 
 		[
 			'a /* ignore this */ > 1 // ignore this too',

--- a/test/plugins/jsepNew.test.js
+++ b/test/plugins/jsepNew.test.js
@@ -1,16 +1,13 @@
 import jsep from '../../src/index.js';
 import jsepNew from '../../src/plugins/jsepNew.js';
-import { testParser, resetJsepHooks } from '../test_utils.js';
+import { testParser, resetJsepDefaults } from '../test_utils.js';
 
 const { test } = QUnit;
 
 (function () {
 	QUnit.module('Plugin:New', (qunit) => {
 		qunit.before(() => jsep.plugins.register(jsepNew));
-		qunit.after(() => {
-			jsep.removeUnaryOp('new');
-			resetJsepHooks();
-		});
+		qunit.after(resetJsepDefaults);
 
 		test('should parse basic "new" expression', (assert) => {
 			testParser('new Date(123)', {

--- a/test/plugins/jsepObject.test.js
+++ b/test/plugins/jsepObject.test.js
@@ -1,16 +1,13 @@
 import jsep from '../../src/index.js';
 import object from '../../src/plugins/jsepObject.js';
-import { testParser, resetJsepHooks } from '../test_utils.js';
+import { testParser, resetJsepDefaults } from '../test_utils.js';
 
 const { test } = QUnit;
 
 (function () {
 	QUnit.module('Plugin:Object', (qunit) => {
 		qunit.before(() => jsep.plugins.register(object));
-		qunit.after(() => {
-			jsep.removeBinaryOp(':');
-			resetJsepHooks();
-		});
+		qunit.after(resetJsepDefaults);
 
 		test('should parse basic object expression', (assert) => {
 			testParser('({ a: 1, b: 2 })', {

--- a/test/plugins/jsepRegex.test.js
+++ b/test/plugins/jsepRegex.test.js
@@ -1,0 +1,99 @@
+import jsep from '../../src/index.js';
+import jsepRegex from '../../src/plugins/jsepRegex.js';
+import {testParser, resetJsepDefaults, esprimaComparisonTest} from '../test_utils.js';
+
+const { test } = QUnit;
+
+(function () {
+	QUnit.module('Plugin:Regex Literal', (qunit) => {
+		qunit.before(() => jsep.plugins.register(jsepRegex));
+		qunit.after(resetJsepDefaults);
+
+		test('should parse basic regular expression', (assert) => {
+			testParser('/abc/', {
+				type: 'Literal',
+				value: /abc/,
+				raw: '/abc/',
+			}, assert);
+		});
+
+		test('should parse basic regex with flags', (assert) => {
+			testParser('/abc/ig', {
+				type: 'Literal',
+				value: /abc/gi,
+				raw: '/abc/ig',
+			}, assert);
+		});
+
+		test('should handle escapes properly', (assert) => {
+			testParser('/\\d{3}/', {
+				type: 'Literal',
+				value: /\d{3}/,
+				raw: '/\\d{3}/',
+			}, assert);
+		});
+
+		test('should parse more complex regex within expression', (assert) => {
+			testParser('a && /[a-z]{3}/ig.test(b)', {
+				type: 'BinaryExpression', // Note: Esprima = LogicalExpression, but but jsep has `&&` as a binary op
+				operator: '&&',
+				left: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				right: {
+					type: 'CallExpression',
+					arguments: [
+						{
+							type: 'Identifier',
+							name: 'b'
+						}
+					],
+					callee: {
+						type: 'MemberExpression',
+						computed: false,
+						object: {
+							type: 'Literal',
+							value: /[a-z]{3}/ig,
+							raw: '/[a-z]{3}/ig'
+						},
+						property: {
+							type: 'Identifier',
+							name: 'test'
+						}
+					}
+				}
+			}, assert);
+		});
+
+		[
+			'/[a-z]{3}/ig.test(b)',
+			'/\d(?=px)/',
+		].forEach((expr) => {
+			test('should match Esprima', function (assert) {
+				esprimaComparisonTest(expr, assert);
+			});
+		});
+
+		[
+			'/\d(?=px)/.test(a)',
+			'a / /123/',
+			'/123/ig["test"](b)',
+			'/123/["test"](b)',
+			'/\\p{Emoji_Presentation}/gu.test("ticket to 大阪 costs ¥2000 👌.")',
+			'/abc/+/123/',
+		].forEach(expr => test(`should not throw an error on expression ${expr}`, (assert) => {
+			testParser(expr, {}, assert);
+		}));
+
+		[
+			'/abc', // unclosed regex
+			'/a/xzw', // invalid flag
+			'/a/xyz.test(a)', // invalid flag
+			'/a(/', // unclosed (
+			'/a[/', // unclosed [
+		].forEach(expr => test(`should give an error for invalid expression ${expr}`, (assert) => {
+			assert.throws(() => jsep(expr));
+		}));
+	});
+}());

--- a/test/plugins/jsepSpread.test.js
+++ b/test/plugins/jsepSpread.test.js
@@ -1,13 +1,13 @@
 import jsep from '../../src/index.js';
 import spread from '../../src/plugins/jsepSpread.js';
-import {resetJsepHooks, testParser} from '../test_utils.js';
+import {resetJsepDefaults, testParser} from '../test_utils.js';
 
 const { test } = QUnit;
 
 (function () {
 	QUnit.module('Plugin:Spread', (qunit) => {
 		qunit.before(() => jsep.plugins.register(spread));
-		qunit.after(resetJsepHooks);
+		qunit.after(resetJsepDefaults);
 
 		test('should parse array spread', (assert) => {
 			testParser('[...a]', {

--- a/test/plugins/jsepTemplateLiteral.test.js
+++ b/test/plugins/jsepTemplateLiteral.test.js
@@ -1,13 +1,13 @@
 import jsep from '../../src/index.js';
 import templateLiteral from '../../src/plugins/jsepTemplateLiteral.js';
-import {testParser, resetJsepHooks} from '../test_utils.js';
+import {testParser, resetJsepDefaults} from '../test_utils.js';
 
 const { test } = QUnit;
 
 (function () {
 	QUnit.module('Plugin:Template Literal', (qunit) => {
 		qunit.before(() => jsep.plugins.register(templateLiteral));
-		qunit.after(resetJsepHooks);
+		qunit.after(resetJsepDefaults);
 
 		test('should parse basic template literal expression', (assert) => {
 			testParser('`hi ${name}`', {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -35,7 +35,7 @@ export function filterProps(larger, smaller) {
 	const rv = (typeof larger.length === 'number') ? [] : {};
 	for (let propName in smaller) {
 		let propVal = smaller[propName];
-		if (typeof propVal === 'string' || typeof propVal === 'number' || typeof propVal === 'boolean' || propVal === null) {
+		if (typeof propVal === 'string' || typeof propVal === 'number' || typeof propVal === 'boolean' || propVal === null || propVal instanceof RegExp) {
 			rv[propName] = larger[propName];
 		}
 		else {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -56,16 +56,30 @@ export function esprimaComparisonTest(str, assert) {
 	return assert.deepEqual(parsedVal, esprimaVal.body[0].expression);
 }
 
-let defaultHooks = {};
+export const defaults = {
+	hooks: {},
+	plugins: Object.assign({}, jsep.plugins.registered),
+	unary_ops: Object.assign({}, jsep.unary_ops),
+	binary_ops: Object.assign({}, jsep.binary_ops),
+	additional_identifier_chars: new Set(jsep.additional_identifier_chars),
+	literals: Object.assign({}, jsep.literals),
+	this_str: jsep.this_str,
+};
 Object.entries(jsep.hooks).forEach(([hookName, fns]) => {
-	defaultHooks[hookName] = [...fns];
+	defaults.hooks[hookName] = [...fns];
 });
 
-export function resetJsepHooks() {
+export function resetJsepDefaults() {
 	for (let key in jsep.hooks) {
 		delete jsep.hooks[key];
 	}
-	Object.entries(defaultHooks).forEach(([hookName, fns]) => {
+	Object.entries(defaults.hooks).forEach(([hookName, fns]) => {
 		jsep.hooks[hookName] = [...fns];
 	});
+	jsep.unary_ops = Object.assign({}, defaults.unary_ops);
+	jsep.binary_ops = Object.assign({}, defaults.binary_ops);
+	jsep.additional_identifier_chars = new Set(defaults.additional_identifier_chars);
+	jsep.literals = Object.assign({}, defaults.literals);
+	jsep.this_str = defaults.this_str;
+	jsep.plugins.registered = Object.assign({}, defaults.plugins);
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,5 +6,6 @@ export * from './plugins/jsepTernary.test.js';
 export * from './plugins/jsepComment.test.js';
 export * from './plugins/jsepNew.test.js';
 export * from './plugins/jsepObject.test.js';
+export * from './plugins/jsepRegex.test.js';
 export * from './plugins/jsepSpread.test.js';
 export * from './plugins/jsepTemplateLiteral.test.js';

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -84,13 +84,54 @@ declare module 'jsep' {
 			| 'ConditionalExpression'
 			| 'ArrayExpression';
 
-		type HookType = 'gobble-expression' | 'after-expression' | 'gobble-token' | 'after-token' | 'gobble-spaces';
-		type HookCallback = (env: { node?: Expression }) => void;
+		export type PossibleExpression = Expression | undefined;
+		export interface HookScope {
+			index: number;
+			readonly expr: string;
+			readonly char: string; // current character of the expression
+			readonly code: number; // current character code of the expression
+			gobbleSpaces: () => void;
+			gobbleExpressions: (number?) => Expression[];
+			gobbleExpression: () => Expression;
+			gobbleBinaryOp: () => PossibleExpression;
+			gobbleBinaryExpression: () => PossibleExpression;
+			gobbleToken: () =>  PossibleExpression;
+			gobbleNumericLiteral: () => PossibleExpression;
+			gobbleStringLiteral: () => PossibleExpression;
+			gobbleIdentifier: () => PossibleExpression;
+			gobbleArguments: (number) => PossibleExpression;
+			gobbleGroup: () => Expression;
+			gobbleArray: () => PossibleExpression;
+			throwError: (string) => void;
+		}
 
-		function hooksAdd(name: HookType, cb: HookCallback): void;
-		function hooksAdd(name: HookType, first: boolean, cb: HookCallback): void;
-		function hooksAdd(obj: { [name in HookType]: HookCallback }): void;
-		function hooksAdd(obj: { [name in HookType]: HookCallback }, first: boolean): void;
+		export type HookType = 'gobble-expression' | 'after-expression' | 'gobble-token' | 'after-token' | 'gobble-spaces';
+		export type HookCallback = (this: HookScope, env: { node?: Expression }) => void;
+		type HookTypeObj = Partial<{ [key in HookType]: HookCallback}>
+
+		export interface IHooks extends HookTypeObj {
+			add(name: HookType, cb: HookCallback): void;
+			add(name: HookType, first: boolean, cb: HookCallback): void;
+			add(obj: { [name in HookType]: HookCallback }): void;
+			add(obj: { [name in HookType]: HookCallback }, first: boolean): void;
+			run(name: string, env: { context?: typeof jsep, node?: Expression }): void;
+		}
+		let hooks: IHooks;
+
+		export interface IPlugin {
+			name: string;
+			init: (this: typeof jsep) => void;
+		}
+		export interface IPlugins {
+			registered: { [name: string]: IPlugin };
+		}
+		let plugins: IPlugins;
+
+		let unary_ops: { [op: string]: any };
+		let binary_ops: { [op: string]: number };
+		let additional_identifier_chars: Set<string>;
+		let literals: { [literal: string]: any };
+		let this_str: string;
 
 		function addBinaryOp(operatorName: string, precedence: number): void;
 


### PR DESCRIPTION
- Remove `jsep.hooksAdd` and just stick with `jsep.hooks.add`. This allows jsep to be reset easier (i.e. between unit tests) without having to re-bind to jsep
- Rename `resetJsepHooks` test utility => `resetJsepDefaults` (which currently includes jsepTernary plugin)
- Update typings