### PR TITLE
RegExp plugin:

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Plugins are registered by calling `jsep.plugins.register()` with the plugin(s) a
 * `jsepComment`: Adds support for ignoring comments: `a /* ignore this */ > 1 // ignore this too`
 * `jsepNew`: Adds 'new' keyword support: `new Date()`
 * `jsepObject`: Adds object expression support: `{ a: 1, b: { c }}`
+* `jsepRegex`: Adds support for regular expression literals: `/[a-z]{2}/ig`
 * `jsepSpread`: Adds support for the spread operator, `fn(...[1, ...a])`. Works with `jsepObject` plugin, too
 * `jsepTemplateLiteral`: Adds template literal support: `` `hi ${name}` ``
 
@@ -163,7 +164,8 @@ export interface HookScope {
     gobbleExpression: () => Expression;
     gobbleBinaryOp: () => PossibleExpression;
     gobbleBinaryExpression: () => PossibleExpression;
-    gobbleToken: () =>  PossibleExpression;
+    gobbleToken: () => PossibleExpression;
+    gobbleTokenProperty: (Expression) => Expression;
     gobbleNumericLiteral: () => PossibleExpression;
     gobbleStringLiteral: () => PossibleExpression;
     gobbleIdentifier: () => PossibleExpression;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,6 +71,7 @@ export default [
 		'jsepComment',
 		'jsepNew',
 		'jsepObject',
+		'jsepRegex',
 		'jsepSpread',
 		'jsepTemplateLiteral',
 	].map(name => ({

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -524,15 +524,22 @@ export class Jsep {
 			return this.runHook('after-token', false);
 		}
 
+		node = this.gobbleTokenProperty(node);
+		return this.runHook('after-token', node);
+	}
+
+	/**
+	 * Gobble properties of of identifiers/strings/arrays/groups.
+	 * e.g. `foo`, `bar.baz`, `foo['bar'].baz`
+	 * It also gobbles function calls:
+	 * e.g. `Math.acos(obj.angle)`
+	 * @param {jsep.Expression} node
+	 * @returns {jsep.Expression}
+	 */
+	gobbleTokenProperty(node) {
 		this.gobbleSpaces();
 
-		ch = this.code;
-
-		// Gobble properties of of identifiers/strings/arrays/groups.
-		// e.g. `foo`, `bar.baz`, `foo['bar'].baz`
-		// It also gobbles function calls:
-		// e.g. `Math.acos(obj.angle)`
-
+		let ch = this.code;
 		while (ch === Jsep.PERIOD_CODE || ch === Jsep.OBRACK_CODE || ch === Jsep.OPAREN_CODE) {
 			this.index++;
 
@@ -571,7 +578,7 @@ export class Jsep {
 			ch = this.code;
 		}
 
-		return this.runHook('after-token', node);
+		return node;
 	}
 
 	/**

--- a/src/plugins/jsepRegex.js
+++ b/src/plugins/jsepRegex.js
@@ -1,0 +1,53 @@
+const FSLASH_CODE = 47; // '/'
+
+export default {
+	name: 'jsepRegex',
+
+	init(jsep) {
+		// Regex literal: /abc123/ig
+		jsep.hooks.add('gobble-token', function gobbleRegexLiteral(env) {
+			if (this.code === FSLASH_CODE) {
+				const patternIndex = ++this.index;
+
+				while (this.index < this.expr.length) {
+					if (this.char === '/') {
+						const pattern = this.expr.slice(patternIndex, this.index);
+
+						let flags = '';
+						while (++this.index < this.expr.length) {
+							const code = this.code;
+							if ((code >= 97 && code <= 122) // a...z
+								|| (code >= 65 && code <= 90) // A...Z
+								|| (code >= 48 && code <= 57)) { // 0-9
+								flags += this.char;
+							}
+							else {
+								break;
+							}
+						}
+
+						let value;
+						try {
+							value = new RegExp(pattern, flags);
+						}
+						catch (e) {
+							this.throwError(e.message);
+						}
+
+						env.node = {
+							type: jsep.LITERAL,
+							value,
+							raw: this.expr.slice(patternIndex - 1, this.index),
+						};
+
+						// allow . [] and () after regex: /regex/.test(a)
+						env.node = this.gobbleTokenProperty(env.node);
+						return env.node;
+					}
+					this.index += 1;
+				}
+				this.throwError('Unclosed Regex');
+			}
+		});
+	},
+};

--- a/test/plugins/jsepRegex.test.js
+++ b/test/plugins/jsepRegex.test.js
@@ -1,0 +1,99 @@
+import jsep from '../../src/index.js';
+import jsepRegex from '../../src/plugins/jsepRegex.js';
+import {testParser, resetJsepDefaults, esprimaComparisonTest} from '../test_utils.js';
+
+const { test } = QUnit;
+
+(function () {
+	QUnit.module('Plugin:Regex Literal', (qunit) => {
+		qunit.before(() => jsep.plugins.register(jsepRegex));
+		qunit.after(resetJsepDefaults);
+
+		test('should parse basic regular expression', (assert) => {
+			testParser('/abc/', {
+				type: 'Literal',
+				value: /abc/,
+				raw: '/abc/',
+			}, assert);
+		});
+
+		test('should parse basic regex with flags', (assert) => {
+			testParser('/abc/ig', {
+				type: 'Literal',
+				value: /abc/gi,
+				raw: '/abc/ig',
+			}, assert);
+		});
+
+		test('should handle escapes properly', (assert) => {
+			testParser('/\\d{3}/', {
+				type: 'Literal',
+				value: /\d{3}/,
+				raw: '/\\d{3}/',
+			}, assert);
+		});
+
+		test('should parse more complex regex within expression', (assert) => {
+			testParser('a && /[a-z]{3}/ig.test(b)', {
+				type: 'BinaryExpression', // Note: Esprima = LogicalExpression, but but jsep has `&&` as a binary op
+				operator: '&&',
+				left: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				right: {
+					type: 'CallExpression',
+					arguments: [
+						{
+							type: 'Identifier',
+							name: 'b'
+						}
+					],
+					callee: {
+						type: 'MemberExpression',
+						computed: false,
+						object: {
+							type: 'Literal',
+							value: /[a-z]{3}/ig,
+							raw: '/[a-z]{3}/ig'
+						},
+						property: {
+							type: 'Identifier',
+							name: 'test'
+						}
+					}
+				}
+			}, assert);
+		});
+
+		[
+			'/[a-z]{3}/ig.test(b)',
+			'/\d(?=px)/',
+		].forEach((expr) => {
+			test('should match Esprima', function (assert) {
+				esprimaComparisonTest(expr, assert);
+			});
+		});
+
+		[
+			'/\d(?=px)/.test(a)',
+			'a / /123/',
+			'/123/ig["test"](b)',
+			'/123/["test"](b)',
+			'/\\p{Emoji_Presentation}/gu.test("ticket to 大阪 costs ¥2000 👌.")',
+			'/abc/+/123/',
+		].forEach(expr => test(`should not throw an error on expression ${expr}`, (assert) => {
+			testParser(expr, {}, assert);
+		}));
+
+		[
+			'/abc', // unclosed regex
+			'/a/xzw', // invalid flag
+			'/a/xyz.test(a)', // invalid flag
+			'/a(/', // unclosed (
+			'/a[/', // unclosed [
+		].forEach(expr => test(`should give an error for invalid expression ${expr}`, (assert) => {
+			assert.throws(() => jsep(expr));
+		}));
+	});
+}());

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -35,7 +35,7 @@ export function filterProps(larger, smaller) {
 	const rv = (typeof larger.length === 'number') ? [] : {};
 	for (let propName in smaller) {
 		let propVal = smaller[propName];
-		if (typeof propVal === 'string' || typeof propVal === 'number' || typeof propVal === 'boolean' || propVal === null) {
+		if (typeof propVal === 'string' || typeof propVal === 'number' || typeof propVal === 'boolean' || propVal === null || propVal instanceof RegExp) {
 			rv[propName] = larger[propName];
 		}
 		else {

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,5 +6,6 @@ export * from './plugins/jsepTernary.test.js';
 export * from './plugins/jsepComment.test.js';
 export * from './plugins/jsepNew.test.js';
 export * from './plugins/jsepObject.test.js';
+export * from './plugins/jsepRegex.test.js';
 export * from './plugins/jsepSpread.test.js';
 export * from './plugins/jsepTemplateLiteral.test.js';


### PR DESCRIPTION
```javascript
/abc/
/abc/ig
/abc/.test(x)
/abc/ig['test'](x)
```

Adds a regex value type for 'Literal' expression types
- Note: modifies jsep to move the object `.[(` -handling code into a function that the plugin can reuse (but code itself is functionally identical).