### PR TITLE
Use all spaces or all commas as separators in call arguments

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -751,6 +751,9 @@ export class Jsep {
 					}
 				}
 			}
+			else if (args.length !== separator_count) {
+				this.throwError('Expected comma');
+			}
 			else {
 				const node = this.gobbleExpression();
 

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -751,7 +751,8 @@ export class Jsep {
 					}
 				}
 			}
-			else if (args.length !== separator_count) {
+			else if (args.length !== separator_count && separator_count !== 0) {
+				// NOTE: `&& separator_count !== 0` allows for either all commas, or all spaces as arguments
 				this.throwError('Expected comma');
 			}
 			else {

--- a/test/jsep.test.js
+++ b/test/jsep.test.js
@@ -22,7 +22,7 @@ import {testParser, testOpExpression, esprimaComparisonTest} from './test_utils.
 	});
 
 	QUnit.test('Function Calls', function (assert) {
-		// testParser("a(b, c(d,e), f)", {});
+		testParser("a(b, c(d,e), f)", {}, assert);
 		testParser('a b + c', {}, assert);
 		testParser('\'a\'.toString()', {}, assert);
 		testParser('[1].length', {}, assert);
@@ -150,6 +150,10 @@ import {testParser, testOpExpression, esprimaComparisonTest} from './test_utils.
 		assert.throws(function () {
 			jsep('check(1,2,)');
 		}, 'detects missing argument (tail)');
+		assert.throws(() => jsep('check(a, b c d) '), 'spaced arg after 1 comma');
+		assert.throws(() => jsep('check(a, b, c d)'), 'spaced arg at end');
+		assert.throws(() => jsep('check(a b, c, d)'), 'spaced arg first');
+		assert.throws(() => jsep('check(a b c, d)'), 'spaced args first');
 	});
 
 	QUnit.test('Uncompleted expression-call/array', function (assert) {

--- a/test/jsep.test.js
+++ b/test/jsep.test.js
@@ -27,6 +27,9 @@ import {testParser, testOpExpression, esprimaComparisonTest} from './test_utils.
 		testParser('\'a\'.toString()', {}, assert);
 		testParser('[1].length', {}, assert);
 		testParser(';', {}, assert);
+		// allow all spaces or all commas to separate arguments
+		testParser('check(a, b, c, d)', {}, assert);
+		testParser('check(a b c d)', {}, assert);
 	});
 
 	QUnit.test('Arrays', function (assert) {


### PR DESCRIPTION
Fixes #156 where the code was gobbling spaces as if they were argument separators. Now it only gobbles the expression on the first arg and after each comma.