### PR TITLE
Object: Remove extraneous hook

### DIFF
--- a/packages/object/src/index.js
+++ b/packages/object/src/index.js
@@ -10,7 +10,7 @@ export default {
 		jsep.addBinaryOp(':', 0.5);
 
 		// Object literal support
-		function gobbleObjectExpression(env) {
+		jsep.hooks.add('gobble-token', function gobbleObjectExpression(env) {
 			if (this.code === OCURLY_CODE) {
 				this.index++;
 				const properties = this.gobbleArguments(CCURLY_CODE)
@@ -43,8 +43,6 @@ export default {
 					properties,
 				};
 			}
-		}
-		jsep.hooks.add('gobble-token', gobbleObjectExpression);
-		jsep.hooks.add('after-token', gobbleObjectExpression);
+		});
 	}
 };


### PR DESCRIPTION
since it was moved from `gobble-expression` to `gobble-token` it doesn't need an `after-token` hook anymore