### PR TITLE
Fix several grammar issues (partial of #162)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"build:watch": "npx rollup -c --watch",
 		"build:all": "pnpm run build -r",
 		"test": "npx http-server -p 49649 --silent & npx node-qunit-puppeteer http://localhost:49649/test/unit_tests.html",
+		"test:all": "pnpm run test -r",
 		"docco": "npx docco src/jsep.js --css=src/docco.css --output=annotated_source/",
 		"lint": "npx eslint src/**/*.js test/*.js test/packages/**/*.js packages/**/*.js"
 	}

--- a/packages/arrow/src/index.js
+++ b/packages/arrow/src/index.js
@@ -6,6 +6,38 @@ export default {
 	init(jsep) {
 		// arrow-function expressions: () => x, v => v, (a, b) => v
 		jsep.addBinaryOp('=>', 0);
+
+		// this hook searches for the special case () => ...
+		// which would normally throw an error because of the invalid LHS to the bin op
+		jsep.hooks.add('gobble-expression', function gobbleEmptyArrowArg(env) {
+			this.gobbleSpaces();
+			if (this.code === jsep.OPAREN_CODE) {
+				const backupIndex = this.index;
+				this.index++;
+
+				this.gobbleSpaces();
+				if (this.code === jsep.CPAREN_CODE) {
+					this.index++;
+
+					const biop = this.gobbleBinaryOp();
+					if (biop === '=>') {
+						// () => ...
+						const body = this.gobbleToken();
+						if (!body) {
+							this.throwError("Expected expression after " + biop);
+						}
+						env.node = {
+							type: ARROW_EXP,
+							params: null,
+							body,
+						};
+						return;
+					}
+				}
+				this.index = backupIndex;
+			}
+		});
+
 		jsep.hooks.add('after-expression', function fixBinaryArrow(env) {
 			if (env.node && env.node.operator === '=>') {
 				env.node = {

--- a/packages/arrow/test/index.test.js
+++ b/packages/arrow/test/index.test.js
@@ -142,9 +142,20 @@ const { test } = QUnit;
 			'a.find(val => key === "abc")',
 			'a.find(() => []).length > 2',
 			'(a || b).find(v => v(1))',
+			'a.find((  ) => 1)',
 		].forEach(expr => {
 			test(`should parse expr "${expr}" without error`, (assert) => {
 				testParser(expr, {}, assert);
+			});
+		});
+
+		[
+			'() =>',
+			'a.find((  ) => )',
+			'a.find((   ',
+		].forEach(expr => {
+			QUnit.test(`should throw on invalid expr "${expr}"`, (assert) => {
+				assert.throws(() => jsep(expr));
 			});
 		});
 	});

--- a/packages/object/src/index.js
+++ b/packages/object/src/index.js
@@ -10,7 +10,7 @@ export default {
 		jsep.addBinaryOp(':', 0.5);
 
 		// Object literal support
-		jsep.hooks.add('gobble-token', function gobbleObjectExpression(env) {
+		function gobbleObjectExpression(env) {
 			if (this.code === OCURLY_CODE) {
 				this.index++;
 				const properties = this.gobbleArguments(CCURLY_CODE)
@@ -43,6 +43,8 @@ export default {
 					properties,
 				};
 			}
-		});
+		}
+		jsep.hooks.add('gobble-token', gobbleObjectExpression);
+		jsep.hooks.add('after-token', gobbleObjectExpression);
 	}
 };

--- a/packages/ternary/src/index.js
+++ b/packages/ternary/src/index.js
@@ -6,7 +6,7 @@ export default {
 	init(jsep) {
 		// Ternary expression: test ? consequent : alternate
 		jsep.hooks.add('after-expression', function gobbleTernary(env) {
-			if (this.code === jsep.QUMARK_CODE) {
+			if (env.node && this.code === jsep.QUMARK_CODE) {
 				this.index++;
 				const test = env.node;
 				const consequent = this.gobbleExpression();

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -388,7 +388,11 @@ export class Jsep {
 
 		// First, try to get the leftmost thing
 		// Then, check to see if there's a binary operator operating on that leftmost thing
+		// Don't gobbleBinaryOp without a left-hand-side
 		left = this.gobbleToken();
+		if (!left) {
+			return left;
+		}
 		biop = this.gobbleBinaryOp();
 
 		// If there wasn't a binary operator, just return the leftmost node
@@ -501,10 +505,14 @@ export class Jsep {
 					(this.index + to_check.length < this.expr.length && !Jsep.isIdentifierPart(this.expr.charCodeAt(this.index + to_check.length)))
 				)) {
 					this.index += tc_len;
+					const argument = this.gobbleToken();
+					if (!argument) {
+						this.throwError('missing unaryOp argument');
+					}
 					return this.runHook('after-token', {
 						type: Jsep.UNARY_EXP,
 						operator: to_check,
-						argument: this.gobbleToken(),
+						argument,
 						prefix: true
 					});
 				}
@@ -627,7 +635,7 @@ export class Jsep {
 			this.throwError('Variable names cannot start with a number (' +
 				number + this.char + ')');
 		}
-		else if (chCode === Jsep.PERIOD_CODE) {
+		else if (chCode === Jsep.PERIOD_CODE || (number.length === 1 && number.charCodeAt(0) === Jsep.PERIOD_CODE)) {
 			this.throwError('Unexpected period');
 		}
 

--- a/test/jsep.test.js
+++ b/test/jsep.test.js
@@ -182,6 +182,21 @@ import {testParser, testOpExpression, esprimaComparisonTest, resetJsepDefaults} 
 		'detects trailing operator');
 	});
 
+	[
+		'!',
+		'*x',
+		'||x',
+		'?a:b',
+		'.',
+		'()()',
+		// '()', should throw 'unexpected )'...
+		'() + 1',
+	].forEach(expr => {
+		QUnit.test(`should throw on invalid expr "${expr}"`, (assert) => {
+			assert.throws(() => jsep(expr));
+		});
+	});
+
 	QUnit.test('Esprima Comparison', function (assert) {
 		([
 			'[1,,3]',
@@ -206,6 +221,9 @@ import {testParser, testOpExpression, esprimaComparisonTest, resetJsepDefaults} 
 			'(Object.variable.toLowerCase()).length == 3',
 			'(Object.variable.toLowerCase())  .  length == 3',
 			'[1] + [2]',
+			'"a"[0]',
+			'[1](2)',
+			'"a".length',
 		]).forEach(function (test) {
 			esprimaComparisonTest(test, assert);
 		});


### PR DESCRIPTION
Fixes most grammer issues reported in #96

`!` => now throws 'missing unaryOp argument'
`*x` => now throws 'unexpected "*"'
`||x` => now throws 'unexpected "|"'
`?a:b` => now throws 'unexpected "?"'
`.` => now throws 'unexpected period'
`"a"[0]` => already works. added test
`[1](2)` => already works. added test
`"a".length` => already works. added test
`()()` => now throws 'unexpected "("'
`() + 1` => now throws 'unexpected +'

`a.this` => Fixed in #162
`a.true` => Fixed in #162

gobbleBinary now only gobbles the operator if there's a left-hand argument. This broke arrow () =>, so it now hooks into gobble-expression specifically to look for that case.
The change to abort earlier in the gobbleBinary() and the invalidUnary error affected the assignment plugin, so it had to move the postfix from after-expression to after-token