### PR TITLE
async/await plugin

### DIFF
--- a/packages/arrow/types/tsd.d.ts
+++ b/packages/arrow/types/tsd.d.ts
@@ -7,5 +7,6 @@ export interface ArrowExpression extends Expression<'ArrowFunctionExpression'> {
 	type: 'ArrowFunctionExpression';
 	params: Expression[] | null;
 	body: Expression;
+	async?: boolean;
 }
 

--- a/packages/async-await/.npmignore
+++ b/packages/async-await/.npmignore
@@ -1,0 +1,6 @@
+*
+*/
+!package.json
+!LICENSE
+!README.md
+!dist/**/*

--- a/packages/async-await/README.md
+++ b/packages/async-await/README.md
@@ -1,0 +1,35 @@
+[npm]: https://img.shields.io/npm/v/@jsep/plugin-async-await
+[npm-url]: https://www.npmjs.com/package/@jsep/plugin-async-await
+[size]: https://packagephobia.now.sh/badge?p=@jsep/plugin-async-await
+[size-url]: https://packagephobia.now.sh/result?p=@jsep/plugin-async-await
+
+[![npm][npm]][npm-url]
+[![size][size]][size-url]
+
+# @jsep/plugin-async-await
+
+A JSEP plugin for adding async/await support. Allows expressions of the form:
+
+```javascript
+jsep('await a');
+jsep('await a.find(async (v1, v2) => await v1(v2))');
+```
+
+## Install
+
+```console
+npm install @jsep/plugin-async-await
+# or
+yarn add @jsep/plugin-async-await
+```
+
+## Usage
+```javascript
+import jsep from 'jsep';
+import jsepAsyncAwait from '@jsep/plugin-async-await';
+jsep.plugins.register(jsepAsyncAwait);
+```
+
+## Meta
+
+[LICENSE (MIT)](/LICENSE)

--- a/packages/async-await/package.json
+++ b/packages/async-await/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "@jsep/plugin-async-await",
+	"version": "1.0.0",
+	"description": "Adds async/await support",
+	"author": "Shelly (https://github.com/6utt3rfly)",
+	"maintainers": [
+		"Eric Smekens (https://github.com/EricSmekens)",
+		"Lea Verou (https://github.com/LeaVerou)",
+		"Shelly (https://github.com/6utt3rfly)"
+	],
+	"homepage": "https://ericsmekens.github.io/jsep/tree/master/packages/async-await#readme",
+	"license": "MIT",
+	"repository": {
+		"url": "EricSmekens/jsep",
+		"directory": "packages/async-await"
+	},
+	"type": "module",
+	"main": "./dist/cjs/index.cjs.js",
+	"module": "./dist/index.js",
+	"types": "types/tsd.d.ts",
+	"peerDependencies": {
+		"jsep": "^0.4.0||^1.0.0"
+	},
+	"devDependencies": {
+		"rollup": "^2.44.0",
+		"rollup-plugin-delete": "^2.0.0"
+	},
+	"engines": {
+		"node": ">= 10.16.0"
+	},
+	"scripts": {
+		"build": "rollup -c ../../plugin.rollup.config.js && cp ../../package-cjs.json dist/cjs/package.json",
+		"test": "cd ../../ && http-server -p 49649 --silent & node-qunit-puppeteer http://localhost:49649/packages/async-await/test/unit_tests.html",
+		"lint": "eslint src/**/*.js test/**/*.js"
+	}
+}

--- a/packages/async-await/src/index.js
+++ b/packages/async-await/src/index.js
@@ -1,0 +1,37 @@
+const ARROW_EXP = 'ArrowFunctionExpression';
+const A_CODE = 97; // a (start of 'async')
+
+export default {
+	name: 'asyncAwait',
+
+	init(jsep) {
+		jsep.hooks.add('gobble-token', function gobbleAsync(env) {
+			if (this.code === A_CODE && !jsep.isIdentifierStart(this.expr.charCodeAt(this.index + 5))) {
+				const sub = this.expr.substr(this.index + 1, 4);
+				if (sub === 'wait') {
+					// found 'await'
+					this.index += 5;
+					const argument = this.gobbleToken();
+					if (!argument) {
+						this.throwError('unexpected \'await\'');
+					}
+					env.node = {
+						type: 'AwaitExpression',
+						argument,
+					};
+				}
+				else if (sub === 'sync') {
+					// found 'async'
+					this.index += 5;
+					env.node = this.gobbleExpression();
+					if (env.node && env.node.type === ARROW_EXP) {
+						env.node.async = true;
+					}
+					else {
+						throw new Error('unexpected \'async\'');
+					}
+				}
+			}
+		});
+	},
+};

--- a/packages/async-await/test/index.test.js
+++ b/packages/async-await/test/index.test.js
@@ -1,0 +1,132 @@
+import jsep from '../../../src/jsep.js';
+import arrow from '../../arrow/src/index.js';
+import asyncAwait from '../src/index.js';
+import { testParser, resetJsepDefaults, findNode } from '../../../test/test_utils.js';
+
+const { test } = QUnit;
+
+(function () {
+	QUnit.module('Plugin:AsyncAwait', (qunit) => {
+		qunit.before(() => jsep.plugins.register(
+			arrow,
+			asyncAwait
+		));
+		qunit.after(resetJsepDefaults);
+
+		test('should parse basic await expression', (assert) => {
+			testParser('await a', {
+				type: "AwaitExpression",
+				argument: {
+					type: "Identifier",
+					name: "a"
+				},
+			}, assert);
+		});
+
+		test('should parse arrow async await (multi args)', (assert) => {
+			testParser('await a.run(async () => await v1)', {
+				type: 'AwaitExpression',
+				argument: {
+					type: 'CallExpression',
+					arguments: [
+						{
+							type: 'ArrowFunctionExpression',
+							params: null,
+							body: {
+								type: 'AwaitExpression',
+								argument: {
+									type: 'Identifier',
+									name: 'v1',
+								},
+							},
+							async: true,
+						},
+					],
+					callee: {},
+				},
+			}, assert);
+		});
+
+		test('should parse arrow async await (no args)', (assert) => {
+			testParser('await a.find(async (v1, v2) => await v1(v2))', {
+				type: 'AwaitExpression',
+				argument: {
+					type: 'CallExpression',
+					arguments: [
+						{
+							type: 'ArrowFunctionExpression',
+							params: [
+								{
+									type: 'Identifier',
+									name: 'v1',
+								},
+								{
+									type: 'Identifier',
+									name: 'v2',
+								}
+							],
+							body: {
+								type: 'AwaitExpression',
+								argument: {
+									type: 'CallExpression',
+									arguments: [
+										{
+											type: 'Identifier',
+											name: 'v2',
+										},
+									],
+									callee: {
+										type: 'Identifier',
+										name: 'v1',
+									},
+								},
+							},
+							async: true,
+						},
+					],
+					callee: {
+						type: 'MemberExpression',
+						computed: false,
+						object: {
+							type: 'Identifier',
+							name: 'a',
+						},
+						property: {
+							type: 'Identifier',
+							name: 'find',
+						},
+					},
+				},
+			}, assert);
+		});
+
+		[
+			'asyncing(123)',
+			'awaiting(123)',
+			'["async", "await"]',
+		].forEach((expr) => {
+			test(`should ignore async/await literal match in ${expr}`, (assert) => {
+				const parsed = jsep(expr);
+				assert.equal(findNode(parsed, n => n.type === 'await' || n.async));
+			});
+		});
+
+		[
+			'await a.find(async v => await v)',
+			'a.find(async ([v]) => await v)',
+			'a.find(async () => await x)',
+		].forEach(expr => {
+			test(`should parse expr "${expr}" without error`, (assert) => {
+				testParser(expr, {}, assert);
+			});
+		});
+
+		[
+			'async 123',
+			'async a + b',
+			'a.find(async () + 2)',
+		].forEach(expr => test(`should throw on invalid async expression, ${expr}`, (assert) => {
+			assert.throws(() => jsep(expr));
+		}));
+	});
+}());

--- a/packages/async-await/test/unit_tests.html
+++ b/packages/async-await/test/unit_tests.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<title>Plugin Tests</title>
+		<base href="../../../">
+		<script src="./test/resources/qunit-2.10.0.js"></script>
+		<link rel=StyleSheet href="./test/resources/qunit-2.10.0.css" type="text/css" media=screen />
+
+		<script src="./test/resources/esprima.js"></script>
+		<script type="module" src="./packages/async-await/test/index.test.js"></script>
+	</head>
+
+	<body>
+		<h1 id="qunit-header">Plugin-Async/Await Unit Tests</h1>
+		<h2 id="qunit-banner"></h2>
+		<div id="qunit-testrunner-toolbar"></div>
+		<h2 id="qunit-userAgent"></h2>
+		<ol id="qunit-tests"></ol>
+	</body>
+</html>

--- a/packages/async-await/types/tsd.d.ts
+++ b/packages/async-await/types/tsd.d.ts
@@ -1,0 +1,9 @@
+import * as jsep from 'jsep';
+import { Expression } from 'jsep';
+export const name: string;
+export function init(this: typeof jsep): void;
+
+export interface AwaitExpression extends Expression<'AwaitExpression'> {
+	type: 'AwaitExpression';
+	argument: Expression;
+}

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -50,6 +50,18 @@ export function testParser(inp, out, assert) {
 	return assert.deepEqual(filterProps(parsedVal, out), out);
 }
 
+export function findNode(ast, condition) {
+	if (typeof ast !== 'object') {
+		return undefined;
+	}
+	if (condition(ast)) {
+		return ast;
+	}
+	return Object
+		.getOwnPropertyNames(ast)
+		.reduce((n, k) => n || findNode(ast[k], condition), undefined);
+}
+
 export function esprimaComparisonTest(str, assert) {
 	const parsedVal = jsep(str);
 	const esprimaVal = esprima.parse(str);

--- a/test/tests.js
+++ b/test/tests.js
@@ -4,6 +4,7 @@ export * from './hooks.test.js';
 export * from './plugins.test.js';
 export * from '../packages/arrow/test/index.test.js';
 export * from '../packages/assignment/test/index.test.js';
+export * from '../packages/async-await/test/index.test.js';
 export * from '../packages/ternary/test/index.test.js';
 export * from '../packages/comment/test/index.test.js';
 export * from '../packages/new/test/index.test.js';


### PR DESCRIPTION
Plugin to add async/await expression support:
`await a`
`await a.find(async (v1, v2) => await v1(v2))`