### PR TITLE
1.0.1 - Republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1 - 2021-08-24
+Fixed support for CommonJS modules. This is only a republish.
+
 ## 1.0.0 - 2021-08-22
 Rewrote to ESM, added a plugin system, and fixed numerous grammar issues. For most standard use-cases, this release should not be a breaking change, as every effort was made to maintain compatibility.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsep",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsep",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "a tiny JavaScript expression parser",
 	"author": "Stephen Oney <swloney@gmail.com> (http://from.so/)",
 	"maintainers": [


### PR DESCRIPTION
I'll create a 1.0.1 tag after this, this should automatically publish the correct package.

(Later on, I will also improve the Github Workflow to support workspaces.