### PR TITLE
Include typings in all builds. Update base Expression type

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!typings/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2 - 2021-08-26
+Republish to include types.
+
 ## 1.0.1 - 2021-08-24
 Fixed support for CommonJS modules. This is only a republish.
 
@@ -28,7 +31,7 @@ Rewrote to ESM, added a plugin system, and fixed numerous grammar issues. For mo
 - conditional (ternary) expressions with no condition now throw `unexpected "?"`
 - `.` now throws `unexpected .`
 - `()()` now throws `unexpected "("`
-- `a.this`, `a.true`, `a.false`, `a.null` now match espimra and treat the property as an identifier instead of a literal or ThisExpression
+- `a.this`, `a.true`, `a.false`, `a.null` now match esprima and treat the property as an identifier instead of a literal or ThisExpression
 
 ### Added
 - Added a plugin system, including plugins for

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsep",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "a tiny JavaScript expression parser",
 	"author": "Stephen Oney <swloney@gmail.com> (http://from.so/)",
 	"maintainers": [

--- a/packages/arrow/.npmignore
+++ b/packages/arrow/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/arrow/CHANGELOG.md
+++ b/packages/arrow/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/arrow/package.json
+++ b/packages/arrow/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/arrow",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds arrow-function support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/arrow/types/tsd.d.ts
+++ b/packages/arrow/types/tsd.d.ts
@@ -3,7 +3,7 @@ import { Expression } from 'jsep';
 export const name: string;
 export function init(this: typeof jsep): void;
 
-export interface ArrowExpression extends Expression<'ArrowFunctionExpression'> {
+export interface ArrowExpression extends Expression {
 	type: 'ArrowFunctionExpression';
 	params: Expression[] | null;
 	body: Expression;

--- a/packages/assignment/.npmignore
+++ b/packages/assignment/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/assignment/CHANGELOG.md
+++ b/packages/assignment/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 1.0.1 - 2021-08-26
+Fix prefix-update expression as part of a BinaryExpression (++a == 2).
+
+Republish with types included.
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/assignment/package.json
+++ b/packages/assignment/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/assignment",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds assignment expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/assignment/types/tsd.d.ts
+++ b/packages/assignment/types/tsd.d.ts
@@ -3,14 +3,14 @@ import { Expression } from 'jsep';
 export const name: string;
 export function init(this: typeof jsep): void;
 
-export interface UpdateExpression extends Expression<'UpdateExpression'> {
+export interface UpdateExpression extends Expression {
 	type: 'UpdateExpression';
 	operator: '++' | '--';
 	argument: Expression;
 	prefix: boolean;
 }
 
-export interface AssignmentExpression extends Expression<'AssignmentExpression'> {
+export interface AssignmentExpression extends Expression {
 	type: 'AssignmentExpression';
 	operator: '='
 		| '*='

--- a/packages/async-await/.npmignore
+++ b/packages/async-await/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/async-await/CHANGELOG.md
+++ b/packages/async-await/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/async-await/package.json
+++ b/packages/async-await/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/async-await",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds async/await support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/async-await/types/tsd.d.ts
+++ b/packages/async-await/types/tsd.d.ts
@@ -3,7 +3,7 @@ import { Expression } from 'jsep';
 export const name: string;
 export function init(this: typeof jsep): void;
 
-export interface AwaitExpression extends Expression<'AwaitExpression'> {
+export interface AwaitExpression extends Expression {
 	type: 'AwaitExpression';
 	argument: Expression;
 }

--- a/packages/comment/.npmignore
+++ b/packages/comment/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/comment/CHANGELOG.md
+++ b/packages/comment/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/comment/package.json
+++ b/packages/comment/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/comment",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds comment expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/new/.npmignore
+++ b/packages/new/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/new/CHANGELOG.md
+++ b/packages/new/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/new/package.json
+++ b/packages/new/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/new",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds 'new' expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/new/types/tsd.d.ts
+++ b/packages/new/types/tsd.d.ts
@@ -3,7 +3,7 @@ import { Expression } from 'jsep';
 export const name: string;
 export function init(this: typeof jsep): void;
 
-export interface NewExpression extends Expression<'NewExpression'> {
+export interface NewExpression extends Expression {
 	type: 'NewExpression';
 	arguments: Expression[];
 	callee: Expression;

--- a/packages/object/.npmignore
+++ b/packages/object/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/object/CHANGELOG.md
+++ b/packages/object/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/object",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds object expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/object/types/tsd.d.ts
+++ b/packages/object/types/tsd.d.ts
@@ -3,12 +3,12 @@ import { Expression } from 'jsep';
 export const name: string;
 export function init(this: typeof jsep): void;
 
-export interface ObjectExpression extends Expression<'ObjectExpression'> {
+export interface ObjectExpression extends Expression {
 	type: 'ObjectExpression';
 	properties: Property[];
 }
 
-export interface Property extends Expression<'Property'> {
+export interface Property extends Expression {
 	type: 'Property';
 	computed: boolean;
 	key: Expression;

--- a/packages/regex/.npmignore
+++ b/packages/regex/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/regex/CHANGELOG.md
+++ b/packages/regex/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/regex/package.json
+++ b/packages/regex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/regex",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds regex expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/spread/.npmignore
+++ b/packages/spread/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/spread/CHANGELOG.md
+++ b/packages/spread/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/spread/package.json
+++ b/packages/spread/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/spread",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds spread (...) expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/spread/types/tsd.d.ts
+++ b/packages/spread/types/tsd.d.ts
@@ -3,7 +3,7 @@ import { Expression } from 'jsep';
 export const name: string;
 export function init(this: typeof jsep): void;
 
-export interface SpreadElement extends Expression<'SpreadElement'> {
+export interface SpreadElement extends Expression {
 	type: 'SpreadElement';
 	argument: Expression;
 }

--- a/packages/template/.npmignore
+++ b/packages/template/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/template/CHANGELOG.md
+++ b/packages/template/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/template",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds template literal expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/packages/template/types/tsd.d.ts
+++ b/packages/template/types/tsd.d.ts
@@ -3,19 +3,19 @@ import { Expression } from 'jsep';
 export const name: string;
 export function init(this: typeof jsep): void;
 
-export interface TaggedTemplateExpression extends Expression<'TaggedTemplateExpression'> {
+export interface TaggedTemplateExpression extends Expression {
 	type: 'TaggedTemplateExpression';
 	readonly tag: Expression;
 	readonly quasi: TemplateLiteral;
 }
 
-export interface TemplateElement extends Expression<'TemplateElement'> {
+export interface TemplateElement extends Expression {
 	type: 'TemplateElement';
 	value: { cooked: string; raw: string };
 	tail: boolean;
 }
 
-export interface TemplateLiteral extends Expression<'TemplateLiteral'> {
+export interface TemplateLiteral extends Expression {
 	type: 'TemplateLiteral';
 	quasis: TemplateElement[];
 	expressions: Expression[];

--- a/packages/ternary/.npmignore
+++ b/packages/ternary/.npmignore
@@ -4,3 +4,4 @@
 !LICENSE
 !README.md
 !dist/**/*
+!types/**/*

--- a/packages/ternary/CHANGELOG.md
+++ b/packages/ternary/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.1 - 2021-08-26
+republish with types included
+
+## 1.0.0 - 2021-08-24
+Initial Release. Code pulled from core of jsep and adapted into a plugin.

--- a/packages/ternary/package.json
+++ b/packages/ternary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jsep-plugin/ternary",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Adds ternary expression support",
 	"author": "Shelly (https://github.com/6utt3rfly)",
 	"maintainers": [

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,10 +1,10 @@
-import { ExpressionType } from 'jsep';
-
 declare module 'jsep' {
 
 	namespace jsep {
-		export interface Expression<T extends string = never> {
-			type: ExpressionType | T;
+		export type baseTypes = string | number | boolean | RegExp | null;
+		export interface Expression {
+			type: string;
+			[key: string]: baseTypes | Expression | Array<baseTypes | Expression>;
 		}
 
 		export interface ArrayExpression extends Expression {
@@ -48,13 +48,6 @@ declare module 'jsep' {
 			raw: string;
 		}
 
-		export interface LogicalExpression extends Expression {
-			type: 'LogicalExpression';
-			operator: string;
-			left: Expression;
-			right: Expression;
-		}
-
 		export interface MemberExpression extends Expression {
 			type: 'MemberExpression';
 			computed: boolean;
@@ -73,7 +66,7 @@ declare module 'jsep' {
 			prefix: boolean;
 		}
 
-		type ExpressionType =
+		export type ExpressionType =
 			'Compound'
 			| 'Identifier'
 			| 'MemberExpression'
@@ -82,9 +75,20 @@ declare module 'jsep' {
 			| 'CallExpression'
 			| 'UnaryExpression'
 			| 'BinaryExpression'
-			| 'LogicalExpression'
 			| 'ConditionalExpression'
 			| 'ArrayExpression';
+
+		export type CoreExpression =
+			ArrayExpression
+			| BinaryExpression
+			| CallExpression
+			| Compound
+			| ConditionalExpression
+			| Identifier
+			| Literal
+			| MemberExpression
+			| ThisExpression
+			| UnaryExpression;
 
 		export type PossibleExpression = Expression | undefined;
 		export interface HookScope {


### PR DESCRIPTION
#160 - include types in all package builds (my fault - sorry!)
#173 - Remove LogicalExpression type from types
#91 - update base Expression type. To ensure compatibility with plugins, rather than renaming Expression to BaseExpression, I added the discriminated union discussed as `CoreExpression` and made the base `Expression` more generic, so the `type` can be any string (allows for extending by plugins without having to use <T extends string>), and provides `[key: string]: ...`

I'm open to alternative suggestions as well