### PR TITLE
fix: firefox compatibility

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -932,9 +932,8 @@ Jsep.max_binop_len = Jsep.getMaxKeyLen(Jsep.binary_ops);
 const jsep = expr => (new Jsep(expr)).parse();
 const staticMethods = Object.getOwnPropertyNames(Jsep);
 staticMethods
-	.slice(staticMethods.indexOf('version'))
 	.forEach((m) => {
-		if (m !== 'name') {
+		if (jsep[m] === undefined && m !== 'prototype') {
 			jsep[m] = Jsep[m];
 		}
 	});


### PR DESCRIPTION
When copying from the static class methods to the jsep function, don't rely on the ordering of keys. Instead, check for properties that are allowed to be set (![prototype, name, length]), by checking if they already exist on jsep. This fixes the "length" is readonly error in firefox (but works in Chrome/Node)

Fixes #178