### PR TITLE
Fix CI's commit message for updated package.json (version bump)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,12 @@
 				}
 			],
 			"@semantic-release/changelog",
-			"@semantic-release/git",
+			[
+				"@semantic-release/git",
+				{
+					"message": "build: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+				}
+			],
 			[
 				"@semantic-release/npm",
 				{


### PR DESCRIPTION
The default is `chore` which isn't a valid type with the commit lint (which gets activated by the 'prepare' script during CI)