### PR TITLE
Exclude tarball from published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 			[
 				"@semantic-release/npm",
 				{
-					"tarballDir": "dist"
+					"tarballDir": "./"
 				}
 			],
 			[
@@ -111,7 +111,7 @@
 				{
 					"assets": [
 						{
-							"path": "dist/*.tgz",
+							"path": "./*.tgz",
 							"label": "build"
 						}
 					]


### PR DESCRIPTION
The last release, 1.0.3, included the tarball within the package published to npm 🤦🏻‍♀️ 

@EricSmekens - it looks like the automated release system worked perfectly (after a minor change with #180 ). I noticed that it included the tarball in the npm package though, so if you'd like to re-release, then I can change this commit message from `ci` type to `fix` type