### PR TITLE
Fix Object/Ternary working together, Support Object member expressions

### DIFF
--- a/packages/object/README.md
+++ b/packages/object/README.md
@@ -11,7 +11,7 @@
 A JSEP plugin for adding object expression support. Allows expressions of the form:
 
 ```javascript
-jsep('{ a: 1, b: { c }}');
+jsep('{ a: 1, b: { c }}[d]');
 ```
 
 ## Install

--- a/packages/object/src/index.js
+++ b/packages/object/src/index.js
@@ -20,6 +20,7 @@ export default {
 								type: PROPERTY,
 								computed: false,
 								key: arg,
+								value: arg,
 								shorthand: true,
 							};
 						}

--- a/packages/object/src/index.js
+++ b/packages/object/src/index.js
@@ -38,10 +38,10 @@ export default {
 						// complex value (i.e. ternary, spread)
 						return arg;
 					});
-				env.node = {
+				env.node = this.gobbleTokenProperty({
 					type: OBJECT_EXP,
 					properties,
-				};
+				});
 			}
 		}
 		jsep.hooks.add('gobble-token', gobbleObjectExpression);

--- a/packages/object/src/index.js
+++ b/packages/object/src/index.js
@@ -7,7 +7,7 @@ export default {
 	name: 'object',
 
 	init(jsep) {
-		jsep.addBinaryOp(':', 0.5);
+		jsep.addBinaryOp(':', 0.95); // > assignment operators at 0.9
 
 		// Object literal support
 		function gobbleObjectExpression(env) {

--- a/packages/object/test/index.test.js
+++ b/packages/object/test/index.test.js
@@ -170,10 +170,220 @@ const { test } = QUnit;
 			}, assert);
 		});
 
+		test('should parse nested complex ternary with object plugin', (assert) => {
+			testParser('a ? b ? 1 : c ? d ? e ? 3 : 4 : 5 : 6 : 7', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				consequent: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'Identifier',
+						name: 'b'
+					},
+					consequent: {
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					},
+					alternate: {
+						type: 'ConditionalExpression',
+						test: {
+							type: 'Identifier',
+							name: 'c'
+						},
+						consequent: {
+							type: 'ConditionalExpression',
+							test: {
+								type: 'Identifier',
+								name: 'd'
+							},
+							consequent: {
+								type: 'ConditionalExpression',
+								test: {
+									type: 'Identifier',
+									name: 'e'
+								},
+								consequent: {
+									type: 'Literal',
+									value: 3,
+									raw: '3'
+								},
+								alternate: {
+									type: 'Literal',
+									value: 4,
+									raw: '4'
+								}
+							},
+							alternate: {
+								type: 'Literal',
+								value: 5,
+								raw: '5'
+							}
+						},
+						alternate: {
+							left: {
+								type: 'Literal',
+								value: 6,
+								raw: '6'
+							},
+							type: 'Literal',
+							value: 6,
+							raw: '6'
+						}
+					}
+				},
+				alternate: {
+					type: 'Literal',
+					value: 7,
+					raw: '7'
+				}
+			}, assert);
+		});
+
+		test('should parse nested ternary consequent/alternates while object plugin loaded', (assert) => {
+			testParser('a ? 0 : b ? 1 : 2', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				consequent: {
+					type: 'Literal',
+					value: 0,
+					raw: '0'
+				},
+				alternate: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'Identifier',
+						name: 'b'
+					},
+					consequent: {
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					},
+					alternate: {
+						type: 'Literal',
+						value: 2,
+						raw: '2'
+					}
+				}
+			}, assert);
+		});
+
+		test('should parse nested ternary with object values', (assert) => {
+			testParser('a ? { a: 1 } : b ? { b: 1 } : { c: 1 }[c] === 1 ? \'c\' : null', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				consequent: {
+					type: 'ObjectExpression',
+					properties: [
+						{
+							type: 'Property',
+							computed: false,
+							key: {
+								type: 'Identifier',
+								name: 'a'
+							},
+							value: {
+								type: 'Literal',
+								value: 1,
+								raw: '1'
+							},
+							shorthand: false
+						}
+					]
+				},
+				alternate: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'Identifier',
+						name: 'b'
+					},
+					consequent: {
+						type: 'ObjectExpression',
+						properties: [
+							{
+								type: 'Property',
+								computed: false,
+								key: {
+									type: 'Identifier',
+									name: 'b'
+								},
+								value: {
+									type: 'Literal',
+									value: 1,
+									raw: '1'
+								},
+								shorthand: false
+							}
+						]
+					},
+					alternate: {
+						type: 'ConditionalExpression',
+						test: {
+							type: 'BinaryExpression',
+							operator: '===',
+							left: {
+								type: 'MemberExpression',
+								computed: true,
+								object: {
+									type: 'ObjectExpression',
+									properties: [
+										{
+											type: 'Property',
+											computed: false,
+											key: {
+												type: 'Identifier',
+												name: 'c'
+											},
+											value: {
+												type: 'Literal',
+												value: 1,
+												raw: '1'
+											},
+											shorthand: false
+										}
+									]
+								},
+								property: {
+									type: 'Identifier',
+									name: 'c'
+								}
+							},
+							right: {
+								type: 'Literal',
+								value: 1,
+								raw: '1'
+							}
+						},
+						consequent: {
+							type: 'Literal',
+							value: 'c',
+							raw: '\'c\''
+						},
+						alternate: {
+							type: 'Literal',
+							value: null,
+							raw: 'null'
+						}
+					}
+				}
+			}, assert);
+		});
+
 		test('should not throw any errors', (assert) => {
 			[
 				'{ a: b ? 1 : 2, c }', // mixed object/ternary
 				'fn({ a: 1 })', // function argument
+				'a ? 0 : b ? 1 : 2', // nested ternary with no ()
 			].forEach(expr => testParser(expr, {}, assert));
 		});
 

--- a/packages/object/test/index.test.js
+++ b/packages/object/test/index.test.js
@@ -89,6 +89,36 @@ const { test } = QUnit;
 			}, assert);
 		});
 
+		test('should parse object with member expression', (assert) => {
+			testParser('{a:1}[b]', {
+				type: 'MemberExpression',
+				computed: true,
+				object: {
+					type: 'ObjectExpression',
+					properties: [
+						{
+							type: 'Property',
+							computed: false,
+							key: {
+								type: 'Identifier',
+								name: 'a'
+							},
+							value: {
+								type: 'Literal',
+								value: 1,
+								raw: '1'
+							},
+							shorthand: false
+						}
+					]
+				},
+				property: {
+					type: 'Identifier',
+					name: 'b'
+				}
+			}, assert);
+		});
+
 		test('should parse nested objects', (assert) => {
 			QUnit.dump.maxDepth = 10;
 			testParser('{ a: { b: { c: 1 } } }', {

--- a/packages/ternary/src/index.js
+++ b/packages/ternary/src/index.js
@@ -32,18 +32,77 @@ export default {
 					};
 				}
 				// if binary operator is custom-added (i.e. object plugin), then correct it to a ternary node:
+				// Note: BinaryExpressions can be stacked (similar to 1 + 1 + 1), so we have to collapse the stack
+				// Only do one level at a time so we can unroll as we pop the ternary stack
+				else if (test.operator === ':') {
+					// this happens when the alternate is a ternary
+					if (!consequent.right) {
+						this.throwError('Expected :');
+					}
+					const node = findLastBinaryNode(consequent);
+					test.right = {
+						type: CONDITIONAL_EXP,
+						test: test.right,
+						consequent: node.left,
+						alternate: node === consequent ? node.right : {
+							// temporary values because we still have to wait to pop the consequent...
+							operator: ':',
+							left: node.right,
+							right: consequent.right,
+						},
+					};
+					env.node = test;
+				}
 				else if (consequent.operator === ':') {
+					convertBinaryToConditional(findLastBinaryNode(consequent), test);
+					env.node = consequent;
+				}
+				else if (consequent.alternate) {
+					// cleanup the temporary placeholder we made, now that we have the consequent
+					let alternate = consequent.alternate;
+					while (alternate.alternate) {
+						alternate = alternate.alternate;
+					}
 					env.node = {
 						type: CONDITIONAL_EXP,
 						test,
-						consequent: consequent.left,
-						alternate: consequent.right,
+						consequent,
+						alternate: alternate.right,
 					};
+					delete alternate.operator;
+					delete alternate.right;
+					Object.assign(alternate, alternate.left);
 				}
 				else {
 					this.throwError('Expected :');
 				}
 			}
 		});
+
+		/**
+		 * @param {jsep.Expression} node
+		 * @returns {jsep.Expression}
+		 */
+		function findLastBinaryNode(node) {
+			while (node.left && node.left.operator === ':') {
+				node = node.left;
+			}
+			return node;
+		}
+
+		/**
+		 * @param {jsep.BinaryExpression} node
+		 * @param {jsep.Expression} test
+		 * @returns {jsep.ConditionalExpression}
+		 */
+		function convertBinaryToConditional(node, test) {
+			node.type = CONDITIONAL_EXP;
+			node.test = test;
+			node.consequent = node.left;
+			node.alternate = node.right;
+			delete node.operator;
+			delete node.left;
+			delete node.right;
+		}
 	},
 };

--- a/packages/ternary/test/index.test.js
+++ b/packages/ternary/test/index.test.js
@@ -19,5 +19,15 @@ const { test } = QUnit;
 			testParser('a ? b : c', { type: 'ConditionalExpression' }, assert);
 			testParser('a||b ? c : d', { type: 'ConditionalExpression' }, assert);
 		});
+
+		[
+			'a ? b : ', // missing value
+			'a ? b', // missing :
+			'a : b ?', // backwards
+		].forEach((expr) => {
+			test(`should give an error for invalid expression ${expr}`, (assert) => {
+				assert.throws(() => jsep(expr));
+			});
+		});
 	});
 }());


### PR DESCRIPTION
The object plugin adds a `:` binary operator which interferes with ternaries. The previous version would work with both objects and ternaries, but not when nested without parentheses. Fixes cases like, `a ? 0 : b ? 1 : 2` and similar.

Fixes #183

Also add support for Object member expressions. Was initially overlooked, but was easy to add with the existing `gobbleTokenProperty()` method