### PR TITLE
Fix assignment/ternary/object interworking

### DIFF
--- a/packages/assignment/src/index.js
+++ b/packages/assignment/src/index.js
@@ -63,9 +63,20 @@ export default {
 		});
 
 		jsep.hooks.add('after-expression', function gobbleAssignment(env) {
-			if (env.node && assignmentOperators.has(env.node.operator)) {
-				env.node.type = 'AssignmentExpression';
+			if (env.node) {
+				// Note: Binaries can be chained in a single expression to respect
+				// operator precedence (i.e. a = b = 1 + 2 + 3)
+				// Update all binary assignment nodes in the tree
+				updateBinariessToAssignments(env.node);
 			}
 		});
+
+		function updateBinariessToAssignments(node) {
+			if (assignmentOperators.has(node.operator)) {
+				node.type = 'AssignmentExpression';
+				updateBinariessToAssignments(node.left);
+				updateBinariessToAssignments(node.right);
+			}
+		}
 	},
 };

--- a/packages/assignment/src/index.js
+++ b/packages/assignment/src/index.js
@@ -1,36 +1,34 @@
 const PLUS_CODE = 43; // +
 const MINUS_CODE = 45; // -
 
-export default {
+const plugin = {
 	name: 'assignment',
 
-	init(jsep) {
-		// Assignment and Update support
-		const assignmentOperators = new Set([
-			'=',
-			'*=',
-			'**=',
-			'/=',
-			'%=',
-			'+=',
-			'-=',
-			'<<=',
-			'>>=',
-			'>>>=',
-			'&=',
-			'^=',
-			'|=',
-		]);
-		const updateOperators = [PLUS_CODE, MINUS_CODE];
-		const updateNodeTypes = [jsep.IDENTIFIER, jsep.MEMBER_EXP];
+	assignmentOperators: new Set([
+		'=',
+		'*=',
+		'**=',
+		'/=',
+		'%=',
+		'+=',
+		'-=',
+		'<<=',
+		'>>=',
+		'>>>=',
+		'&=',
+		'^=',
+		'|=',
+	]),
+	updateOperators: [PLUS_CODE, MINUS_CODE],
+	assignmentPrecedence: 0.9,
 
-		// See operator precedence https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
-		// We need lower priority than || and && which start at 1
-		assignmentOperators.forEach(op => jsep.addBinaryOp(op, 0.9));
+	init(jsep) {
+		const updateNodeTypes = [jsep.IDENTIFIER, jsep.MEMBER_EXP];
+		plugin.assignmentOperators.forEach(op => jsep.addBinaryOp(op, plugin.assignmentPrecedence));
 
 		jsep.hooks.add('gobble-token', function gobbleUpdatePrefix(env) {
 			const code = this.code;
-			if (updateOperators.some(c => c === code && c === this.expr.charCodeAt(this.index + 1))) {
+			if (plugin.updateOperators.some(c => c === code && c === this.expr.charCodeAt(this.index + 1))) {
 				this.index += 2;
 				env.node = {
 					type: 'UpdateExpression',
@@ -47,7 +45,7 @@ export default {
 		jsep.hooks.add('after-token', function gobbleUpdatePostfix(env) {
 			if (env.node) {
 				const code = this.code;
-				if (updateOperators.some(c => c === code && c === this.expr.charCodeAt(this.index + 1))) {
+				if (plugin.updateOperators.some(c => c === code && c === this.expr.charCodeAt(this.index + 1))) {
 					if (!updateNodeTypes.includes(env.node.type)) {
 						this.throwError(`Unexpected ${env.node.operator}`);
 					}
@@ -72,7 +70,7 @@ export default {
 		});
 
 		function updateBinariessToAssignments(node) {
-			if (assignmentOperators.has(node.operator)) {
+			if (plugin.assignmentOperators.has(node.operator)) {
 				node.type = 'AssignmentExpression';
 				updateBinariessToAssignments(node.left);
 				updateBinariessToAssignments(node.right);
@@ -80,3 +78,4 @@ export default {
 		}
 	},
 };
+export default plugin;

--- a/packages/assignment/test/index.test.js
+++ b/packages/assignment/test/index.test.js
@@ -81,6 +81,85 @@ const { test } = QUnit;
 			}, assert);
 		});
 
+		test('should correctly parse chained assignment in ternary', (assert) => {
+			testParser('a = b = c ? d : e = 2', {
+				type: 'AssignmentExpression',
+				operator: '=',
+				left: {
+					type: 'AssignmentExpression',
+					operator: '=',
+					left: {
+						type: 'Identifier',
+						name: 'a'
+					},
+					right: {
+						type: 'Identifier',
+						name: 'b'
+					}
+				},
+				right: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'Identifier',
+						name: 'c'
+					},
+					consequent: {
+						type: 'Identifier',
+						name: 'd'
+					},
+					alternate: {
+						type: 'AssignmentExpression',
+						operator: '=',
+						left: {
+							type: 'Identifier',
+							name: 'e'
+						},
+						right: {
+							type: 'Literal',
+							value: 2,
+							raw: '2'
+						}
+					}
+				}
+			}, assert);
+		});
+
+		test('should correctly parse assignment in ternary alternate', (assert) => {
+			testParser('a ? fn(a) : a = 1', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				consequent: {
+					type: 'CallExpression',
+					arguments: [
+						{
+							type: 'Identifier',
+							name: 'a'
+						}
+					],
+					callee: {
+						type: 'Identifier',
+						name: 'fn'
+					}
+				},
+				alternate: {
+					type: 'AssignmentExpression',
+					operator: '=',
+					left: {
+						type: 'Identifier',
+						name: 'a'
+					},
+					right: {
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					}
+				}
+			}, assert);
+		});
+
 		[
 			{ expr: 'a++', expect: { operator: '++', prefix: false } },
 			{ expr: 'a--', expect: { operator: '--', prefix: false } },

--- a/packages/assignment/test/index.test.js
+++ b/packages/assignment/test/index.test.js
@@ -41,6 +41,46 @@ const { test } = QUnit;
 			}, assert);
 		}));
 
+		test('should correctly parse chained assignment', (assert) => {
+			testParser('a = b = c + 1 = d', {
+				type: 'AssignmentExpression',
+				operator: '=',
+				left: {
+					type: 'AssignmentExpression',
+					operator: '=',
+					left: {
+						type: 'AssignmentExpression',
+						operator: '=',
+						left: {
+							type: 'Identifier',
+							name: 'a'
+						},
+						right: {
+							type: 'Identifier',
+							name: 'b'
+						}
+					},
+					right: {
+						type: 'BinaryExpression',
+						operator: '+',
+						left: {
+							type: 'Identifier',
+							name: 'c'
+						},
+						right: {
+							type: 'Literal',
+							value: 1,
+							raw: '1'
+						}
+					}
+				},
+				right: {
+					type: 'Identifier',
+					name: 'd'
+				}
+			}, assert);
+		});
+
 		[
 			{ expr: 'a++', expect: { operator: '++', prefix: false } },
 			{ expr: 'a--', expect: { operator: '--', prefix: false } },

--- a/packages/assignment/types/tsd.d.ts
+++ b/packages/assignment/types/tsd.d.ts
@@ -1,6 +1,9 @@
 import * as jsep from 'jsep';
 import { Expression } from 'jsep';
 export const name: string;
+export const assignmentOperators: Set<string>;
+export const updateOperators: number[];
+export const assignmentPrecedence: number;
 export function init(this: typeof jsep): void;
 
 export interface UpdateExpression extends Expression {

--- a/packages/object/test/index.test.js
+++ b/packages/object/test/index.test.js
@@ -224,11 +224,6 @@ const { test } = QUnit;
 							}
 						},
 						alternate: {
-							left: {
-								type: 'Literal',
-								value: 6,
-								raw: '6'
-							},
 							type: 'Literal',
 							value: 6,
 							raw: '6'

--- a/packages/ternary/src/index.js
+++ b/packages/ternary/src/index.js
@@ -76,6 +76,20 @@ export default {
 				else {
 					this.throwError('Expected :');
 				}
+
+				// ? and : precedence are before '||' (which defaults to 1)
+				// object plugin sets : precedence to 0.95, so check for less than that
+				// (which would capture assignment operators, which the plugin sets at 0.9)
+				if (env.node.test && env.node.test.operator && jsep.binary_ops[env.node.test.operator] < 0.95) {
+					const node = env.node;
+					env.node = node.test;
+					env.node.right = {
+						type: CONDITIONAL_EXP,
+						test: node.test.right,
+						consequent: node.consequent,
+					 alternate: node.alternate,
+					};
+				}
 			}
 		});
 

--- a/packages/ternary/test/index.test.js
+++ b/packages/ternary/test/index.test.js
@@ -15,9 +15,200 @@ const { test } = QUnit;
 			});
 		});
 
-		test('should result in ConditionalExpression', function (assert) {
-			testParser('a ? b : c', { type: 'ConditionalExpression' }, assert);
+		test('should parse binary op with ConditionalExpression', function (assert) {
 			testParser('a||b ? c : d', { type: 'ConditionalExpression' }, assert);
+		});
+
+		test('should parse minimal ternary', (assert) => {
+			testParser('a ? b : c', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				consequent: {
+					type: 'Identifier',
+					name: 'b'
+				},
+				alternate: {
+					type: 'Identifier',
+					name: 'c'
+				}
+			}, assert);
+		});
+
+		test('should parse secondary ternary on consequent side', (assert) => {
+			testParser('a ? b ? c : 1 : 2', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				alternate: {
+					type: 'Literal',
+					value: 2,
+					raw: '2'
+				},
+				consequent: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'Identifier',
+						name: 'b'
+					},
+					consequent: {
+						type: 'Identifier',
+						name: 'c'
+					},
+					alternate: {
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					}
+				}
+			}, assert);
+		});
+
+		test('should parse secondary ternary on alternate side', (assert) => {
+			testParser('a ? b : c ? 1 : 2', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				consequent: {
+					type: 'Identifier',
+					name: 'b'
+				},
+				alternate: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'Identifier',
+						name: 'c'
+					},
+					consequent: {
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					},
+					alternate: {
+						type: 'Literal',
+						value: 2,
+						raw: '2'
+					}
+				}
+			}, assert);
+		});
+
+		test('should parse 3 level ternaries with mixed consequent/alternate', (assert) => {
+			testParser('a ? b ? 1 : c ? 5 : 6 : 7', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				alternate: {
+					type: 'Literal',
+					value: 7,
+					raw: '7'
+				},
+				consequent: {
+					test: {
+						type: 'Identifier',
+						name: 'b'
+					},
+					alternate: {
+						type: 'ConditionalExpression',
+						test: {
+							type: 'Identifier',
+							name: 'c'
+						},
+						consequent: {
+							type: 'Literal',
+							value: 5,
+							raw: '5'
+						},
+						alternate: {
+							type: 'Literal',
+							value: 6,
+							raw: '6'
+						}
+					},
+					consequent: {
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					},
+					type: 'ConditionalExpression'
+				}
+			}, assert);
+		});
+
+		test('should parse 5-level ternaries mixed consequent/alternate', function (assert) {
+			testParser('a ? b ? 1 : c ? d ? e ? 3 : 4 : 5 : 6 : 7', {
+				type: 'ConditionalExpression',
+				test: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				consequent: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'Identifier',
+						name: 'b'
+					},
+					consequent: {
+						type: 'Literal',
+						value: 1,
+						raw: '1'
+					},
+					alternate: {
+						type: 'ConditionalExpression',
+						test: {
+							type: 'Identifier',
+							name: 'c'
+						},
+						consequent: {
+							type: 'ConditionalExpression',
+							test: {
+								type: 'Identifier',
+								name: 'd'
+							},
+							consequent: {
+								type: 'ConditionalExpression',
+								test: {
+									type: 'Identifier',
+									name: 'e'
+								},
+								consequent: {
+									type: 'Literal',
+									value: 3,
+									raw: '3'
+								},
+								alternate: {
+									type: 'Literal',
+									value: 4,
+									raw: '4'
+								}
+							},
+							alternate: {
+								type: 'Literal',
+								value: 5,
+								raw: '5'
+							}
+						},
+						alternate: {
+							type: 'Literal',
+							value: 6,
+							raw: '6'
+						}
+					}
+				},
+				alternate: {
+					type: 'Literal',
+					value: 7,
+					raw: '7'
+				}
+			}, assert);
 		});
 
 		[

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -53,6 +53,7 @@ declare module 'jsep' {
 			computed: boolean;
 			object: Expression;
 			property: Expression;
+			optional?: boolean;
 		}
 
 		export interface ThisExpression extends Expression {


### PR DESCRIPTION
assignment precedence is lower than conditional precedence. Since conditionals are parsed in the expression stream (rather than as a binary expression), the precedence can't be adjusted. Instead, after creating a conditional node, check to see if it set a lower priority binary expression as the test, so it can swap the estree parts.

Further, I noticed that assignment operators were not respecting binaryExpression chains (i.e. `a = b = c + 2`), so that fix is included as well.

I also thought it would be worthwhile to expose the assignment operators so that they could be adjusted by the user, if needed (i.e. for different versions of node).

I also added more test cases and cleaned up a few minor types and tests

fixes #188
fixes #189