### PR TITLE
fix: literal 'raw' value now matches input string

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -681,7 +681,8 @@ export class Jsep {
 	 */
 	gobbleStringLiteral() {
 		let str = '';
-		let quote = this.expr.charAt(this.index++);
+		const startIndex = this.index;
+		const quote = this.expr.charAt(this.index++);
 		let closed = false;
 
 		while (this.index < this.expr.length) {
@@ -717,7 +718,7 @@ export class Jsep {
 		return {
 			type: Jsep.LITERAL,
 			value: str,
-			raw: quote + str + quote
+			raw: this.expr.substring(startIndex, this.index),
 		};
 	}
 

--- a/test/jsep.test.js
+++ b/test/jsep.test.js
@@ -21,6 +21,7 @@ import {testParser, testOpExpression, esprimaComparisonTest, resetJsepDefaults} 
 			["'a \\b b'", "a \b b"],
 			["'a \\f b'", "a \f b"],
 			["'a \\v b'", "a \v b"],
+			["'a \\\ b'", "a \ b"],
 		].forEach((t) => QUnit.test(`Should parse ${t[0]}`, (assert) => {
 			testParser(t[0], { value: t[1], raw: t[0] }, assert);
 		}));

--- a/test/jsep.test.js
+++ b/test/jsep.test.js
@@ -11,6 +11,21 @@ import {testParser, testOpExpression, esprimaComparisonTest, resetJsepDefaults} 
 		testParser('12.3', { value: 12.3 }, assert);
 	});
 
+	QUnit.module('Literal Parsing', () => {
+		[
+			["'a \\w b'", "a w b"],
+			["'a \\' b'", "a ' b"],
+			["'a \\n b'", "a \n b"],
+			["'a \\r b'", "a \r b"],
+			["'a \\t b'", "a \t b"],
+			["'a \\b b'", "a \b b"],
+			["'a \\f b'", "a \f b"],
+			["'a \\v b'", "a \v b"],
+		].forEach((t) => QUnit.test(`Should parse ${t[0]}`, (assert) => {
+			testParser(t[0], { value: t[1], raw: t[0] }, assert);
+		}));
+	});
+
 	QUnit.test('Variables', function (assert) {
 		testParser('abc', { name: 'abc' }, assert);
 		testParser('a.b[c[0]]', {


### PR DESCRIPTION
copy original input string literal to 'raw' instead of using the parsed value

fixes #192