### PR TITLE
Add right-associative support for binary operators

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,14 @@
 		"browser": true,
 		"node": true
 	},
+	"overrides": [
+		{
+			"files": ["test/**/*.js", "*.test.js"],
+			"parserOptions": {
+				"ecmaVersion": 7
+			}
+		}
+	],
 	"rules": {
 		"semi": 1,
 		"no-dupe-args": 1,

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ const parse_tree = Jsep.parse('1 + 1');
 
 ```javascript
 // Add a custom ^ binary operator with precedence 10
+// (Note that higher number = higher precedence)
 jsep.addBinaryOp("^", 10);
+
+// Add exponentiation operator (right-to-left)
+jsep.addBinaryOp('**', 11, true);
 
 // Add a custom @ unary operator
 jsep.addUnaryOp('@');

--- a/test/jsep.test.js
+++ b/test/jsep.test.js
@@ -61,15 +61,27 @@ import {testParser, testOpExpression, esprimaComparisonTest, resetJsepDefaults} 
 		}, assert);
 	});
 
-	QUnit.test('Ops', function (assert) {
-		testOpExpression('1', assert);
-		testOpExpression('1+2', assert);
-		testOpExpression('1*2', assert);
-		testOpExpression('1*(2+3)', assert);
-		testOpExpression('(1+2)*3', assert);
-		testOpExpression('(1+2)*3+4-2-5+2/2*3', assert);
-		testOpExpression('1 + 2-   3*	4 /8', assert);
-		testOpExpression('\n1\r\n+\n2\n', assert);
+	QUnit.module('Ops', function (qunit) {
+		qunit.before(() => {
+			jsep.addBinaryOp('**', 11, true); // ES2016, right-associative
+		});
+		qunit.after(resetJsepDefaults);
+
+		[
+			'1',
+			'1+2',
+			'1*2',
+			'1*(2+3)',
+			'(1+2)*3',
+			'(1+2)*3+4-2-5+2/2*3',
+			'1 + 2-   3*	4 /8',
+			'\n1\r\n+\n2\n',
+			'1 + -2',
+			'-1 + -2 * -3 * 2',
+			'2 ** 3 ** 4',
+			'2 ** 3 ** 4 * 5 ** 6 ** 7 * (8 + 9)',
+			'(2 ** 3) ** 4 * (5 ** 6 ** 7) * (8 + 9)',
+		].forEach(expr => QUnit.test(`Expr: ${expr}`, assert => testOpExpression(expr, assert)));
 	});
 
 	QUnit.test('Custom operators', function (assert) {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -6,6 +6,7 @@ export const binOps = {
 	'*': (a, b) => a * b,
 	'/': (a, b) => a / b,
 	'%': (a, b) => a % b,
+	'**': (a, b) => a ** b, // ES2016
 };
 
 export const unOps = {

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -136,11 +136,12 @@ declare module 'jsep' {
 
 		let unary_ops: { [op: string]: any };
 		let binary_ops: { [op: string]: number };
+		let right_associative: Set<string>;
 		let additional_identifier_chars: Set<string>;
 		let literals: { [literal: string]: any };
 		let this_str: string;
 
-		function addBinaryOp(operatorName: string, precedence: number): void;
+		function addBinaryOp(operatorName: string, precedence: number, rightToLeft?: boolean): void;
 
 		function addUnaryOp(operatorName: string): void;
 


### PR DESCRIPTION
Adds support for right-to-left parsing of binary operators (i.e. **, assignment operators, ternary)

Adds a new Set, `right_associative` which defaults empty and is only filled with binary operators that are set to right-associative. `addBinaryOp` takes a 3rd arg to set/clear right associativity.

The binary operator parsing loop has a small change to order the nodes correctly based on left-to-right / right-to-left, checking if the binop is in the right_associative set.


fixes #195