### PR TITLE
ci: fix sementic-release for jsep not including ternary in its checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 	"release": {
 		"commitPaths": [
 			"src/",
+			"packages/ternary/src/",
 			"types",
 			"typings/",
 			".npmignore",

--- a/release.sh
+++ b/release.sh
@@ -9,6 +9,6 @@ pnpx semantic-release "$@"
 
 packages=($(ls -d packages/*))
 for package in "${packages[@]}"; do
-  echo "Semantic-Release $package"
+  printf "\n\nSemantic-Release $package\n"
   (cd $package && pwd && pnpx semantic-release -e semantic-release-monorepo "$@")
 done


### PR DESCRIPTION
If a commit is made just to the `/packages/ternary/` folder, semantic-release was ignoring it and would not trigger a new release (but other commits to the jsep source, that triggered a release, would still incorporate the updated ternary package)

Note: no need to manually force a release because everything is correct right now.