### PR TITLE
fix assignment + object + ternary

### DIFF
--- a/packages/assignment/src/index.js
+++ b/packages/assignment/src/index.js
@@ -24,7 +24,7 @@ const plugin = {
 
 	init(jsep) {
 		const updateNodeTypes = [jsep.IDENTIFIER, jsep.MEMBER_EXP];
-		plugin.assignmentOperators.forEach(op => jsep.addBinaryOp(op, plugin.assignmentPrecedence));
+		plugin.assignmentOperators.forEach(op => jsep.addBinaryOp(op, plugin.assignmentPrecedence, true));
 
 		jsep.hooks.add('gobble-token', function gobbleUpdatePrefix(env) {
 			const code = this.code;
@@ -65,15 +65,22 @@ const plugin = {
 				// Note: Binaries can be chained in a single expression to respect
 				// operator precedence (i.e. a = b = 1 + 2 + 3)
 				// Update all binary assignment nodes in the tree
-				updateBinariessToAssignments(env.node);
+				updateBinariesToAssignments(env.node);
 			}
 		});
 
-		function updateBinariessToAssignments(node) {
+		function updateBinariesToAssignments(node) {
 			if (plugin.assignmentOperators.has(node.operator)) {
 				node.type = 'AssignmentExpression';
-				updateBinariessToAssignments(node.left);
-				updateBinariessToAssignments(node.right);
+				updateBinariesToAssignments(node.left);
+				updateBinariesToAssignments(node.right);
+			}
+			else if (!node.operator) {
+				Object.values(node).forEach((val) => {
+					if (val && typeof val === 'object') {
+						updateBinariesToAssignments(val);
+					}
+				});
 			}
 		}
 	},

--- a/packages/assignment/test/index.test.js
+++ b/packages/assignment/test/index.test.js
@@ -42,41 +42,32 @@ const { test } = QUnit;
 		}));
 
 		test('should correctly parse chained assignment', (assert) => {
-			testParser('a = b = c + 1 = d', {
+			testParser('a = b = c = d', {
 				type: 'AssignmentExpression',
 				operator: '=',
 				left: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				right: {
 					type: 'AssignmentExpression',
 					operator: '=',
 					left: {
-						type: 'AssignmentExpression',
-						operator: '=',
-						left: {
-							type: 'Identifier',
-							name: 'a'
-						},
-						right: {
-							type: 'Identifier',
-							name: 'b'
-						}
+						type: 'Identifier',
+						name: 'b'
 					},
 					right: {
-						type: 'BinaryExpression',
-						operator: '+',
+						type: 'AssignmentExpression',
+						operator: '=',
 						left: {
 							type: 'Identifier',
 							name: 'c'
 						},
 						right: {
-							type: 'Literal',
-							value: 1,
-							raw: '1'
+							type: 'Identifier',
+							name: 'd'
 						}
 					}
-				},
-				right: {
-					type: 'Identifier',
-					name: 'd'
 				}
 			}, assert);
 		});
@@ -86,38 +77,38 @@ const { test } = QUnit;
 				type: 'AssignmentExpression',
 				operator: '=',
 				left: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				right: {
 					type: 'AssignmentExpression',
 					operator: '=',
 					left: {
 						type: 'Identifier',
-						name: 'a'
+						name: 'b'
 					},
 					right: {
-						type: 'Identifier',
-						name: 'b'
-					}
-				},
-				right: {
-					type: 'ConditionalExpression',
-					test: {
-						type: 'Identifier',
-						name: 'c'
-					},
-					consequent: {
-						type: 'Identifier',
-						name: 'd'
-					},
-					alternate: {
-						type: 'AssignmentExpression',
-						operator: '=',
-						left: {
+						type: 'ConditionalExpression',
+						test: {
 							type: 'Identifier',
-							name: 'e'
+							name: 'c'
 						},
-						right: {
-							type: 'Literal',
-							value: 2,
-							raw: '2'
+						consequent: {
+							type: 'Identifier',
+							name: 'd'
+						},
+						alternate: {
+							type: 'AssignmentExpression',
+							operator: '=',
+							left: {
+								type: 'Identifier',
+								name: 'e'
+							},
+							right: {
+								type: 'Literal',
+								value: 2,
+								raw: '2'
+							}
 						}
 					}
 				}
@@ -155,6 +146,59 @@ const { test } = QUnit;
 						type: 'Literal',
 						value: 1,
 						raw: '1'
+					}
+				}
+			}, assert);
+		});
+
+		test('should correctly parse assignment in consequent and alternate', (assert) => {
+			testParser('a = b + 2 ? c = 3 : d = 4', {
+				type: 'AssignmentExpression',
+				operator: '=',
+				left: {
+					type: 'Identifier',
+					name: 'a'
+				},
+				right: {
+					type: 'ConditionalExpression',
+					test: {
+						type: 'BinaryExpression',
+						left: {
+							type: 'Identifier',
+							name: 'b'
+						},
+						operator: '+',
+						right: {
+							type: 'Literal',
+							value: 2,
+							raw: '2'
+						}
+					},
+					consequent: {
+						type: 'AssignmentExpression',
+						operator: '=',
+						left: {
+							type: 'Identifier',
+							name: 'c'
+						},
+						right: {
+							type: 'Literal',
+							value: 3,
+							raw: '3'
+						}
+					},
+					alternate: {
+						type: 'AssignmentExpression',
+						operator: '=',
+						left: {
+							type: 'Identifier',
+							name: 'd'
+						},
+						right: {
+							type: 'Literal',
+							value: 4,
+							raw: '4'
+						}
 					}
 				}
 			}, assert);

--- a/packages/object/test/index.test.js
+++ b/packages/object/test/index.test.js
@@ -374,20 +374,20 @@ const { test } = QUnit;
 			}, assert);
 		});
 
-		test('should not throw any errors', (assert) => {
-			[
-				'{ a: b ? 1 : 2, c }', // mixed object/ternary
-				'fn({ a: 1 })', // function argument
-				'a ? 0 : b ? 1 : 2', // nested ternary with no ()
-			].forEach(expr => testParser(expr, {}, assert));
-		});
+		[
+			'{ a: b ? 1 : 2, c }', // mixed object/ternary
+			'fn({ a: 1 })', // function argument
+			'a ? 0 : b ? 1 : 2', // nested ternary with no ()
+		].forEach(expr => test(`should not throw an error ${expr}`, (assert) => {
+			testParser(expr, {}, assert);
+		}));
 
-		test('should give an error for invalid expressions', (assert) => {
-			[
-				'{ a: }', // missing value
-				'{ a: 1 ', // missing }
-				'{ a: 2 ? 3, b }', // missing : in ternary
-			].forEach(expr => assert.throws(() => jsep(expr)));
-		});
+		[
+			'{ a: }', // missing value
+			'{ a: 1 ', // missing }
+			'{ a: 2 ? 3, b }', // missing : in ternary
+		].forEach(expr => test(`should give an error for invalid expression: "${expr}"`, (assert) => {
+			assert.throws(() => jsep(expr));
+		}));
 	});
 }());

--- a/packages/ternary/src/index.js
+++ b/packages/ternary/src/index.js
@@ -30,6 +30,18 @@ export default {
 						consequent,
 						alternate,
 					};
+
+					// check for operators of higher priority than ternary (i.e. assignment)
+					// jsep sets || at 1, and assignment at 0.9, and conditional should be between them
+					if (test.operator && jsep.binary_ops[test.operator] <= 0.9) {
+						let newTest = test;
+						while (newTest.right.operator && jsep.binary_ops[newTest.right.operator] <= 0.9) {
+							newTest = newTest.right;
+						}
+						env.node.test = newTest.right;
+						newTest.right = env.node;
+						env.node = test;
+					}
 				}
 				else {
 					this.throwError('Expected :');

--- a/test/packages/combinedPlugins.test.js
+++ b/test/packages/combinedPlugins.test.js
@@ -95,6 +95,7 @@ const { test } = QUnit;
 			'fn(..."abc")',
 			'[1, ...[2, 3]]',
 			'[1, ...(a ? b : c)]',
+			'{ ...a, ...b, c }',
 			'`hi ${name}`',
 			'abc`token ${`nested ${`deeply` + "str"} blah`}`',
 			'`hi ${last}, ${first} ${middle}!`',


### PR DESCRIPTION
Issues arise with the ternary and assignment operators when `:` is added as a binary operator, so I rewrote the object plugin to remove the binary operator and instead parse in sequence (similar to how the ternary works)

That allows removing the special `:` handling in the conditional plugin, and makes it much simpler

The assignment operator plugin now sets the new right-to-left associativity option with its binary operators. In addition, the ternary plugin now checks for binary operators of higher precedence than itself so that it can change from returning a ConditionalExpression node to placing the conditional node deeper into the binary tree. The assignment plugin now also corrects BinaryExpression => AssignmentExpressions on other node types (i.e. ConditionalExpression)

Fixes #189 