### PR TITLE
ci: allow publishing pre-releases on next, beta, and alpha branches

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, next, beta, alpha ]
 
 jobs:
   build:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - master
+      - next
+      - beta
+      - alpha
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
minor change to allow creating PRs against (and verifying they pass tests), as well as publishing next, beta, and alpha pre-releases