### PR TITLE
Fix assignment to arrow, and nested arrow

### DIFF
--- a/packages/arrow/src/index.js
+++ b/packages/arrow/src/index.js
@@ -22,7 +22,7 @@ export default {
 					const biop = this.gobbleBinaryOp();
 					if (biop === '=>') {
 						// () => ...
-						const body = this.gobbleToken();
+						const body = this.gobbleBinaryExpression();
 						if (!body) {
 							this.throwError("Expected expression after " + biop);
 						}

--- a/packages/arrow/src/index.js
+++ b/packages/arrow/src/index.js
@@ -5,7 +5,7 @@ export default {
 
 	init(jsep) {
 		// arrow-function expressions: () => x, v => v, (a, b) => v
-		jsep.addBinaryOp('=>', 0.1, true);
+		jsep.addBinaryOp('=>', 0.95, true);
 
 		// this hook searches for the special case () => ...
 		// which would normally throw an error because of the invalid LHS to the bin op

--- a/packages/arrow/test/index.test.js
+++ b/packages/arrow/test/index.test.js
@@ -137,6 +137,39 @@ const { test } = QUnit;
 			}, assert);
 		});
 
+		test('should parse nested arrow function correctly', (assert) => {
+			testParser('x => y => a + b', {
+				type: 'ArrowFunctionExpression',
+				params: [
+					{
+						type: 'Identifier',
+						name: 'x'
+					}
+				],
+				body: {
+					type: 'ArrowFunctionExpression',
+					params: [
+						{
+							type: 'Identifier',
+							name: 'y'
+						}
+					],
+					body: {
+						type: 'BinaryExpression',
+						operator: '+',
+						left: {
+							type: 'Identifier',
+							name: 'a'
+						},
+						right: {
+							type: 'Identifier',
+							name: 'b'
+						}
+					}
+				}
+			}, assert);
+		});
+
 		[
 			'(["a", "b"].find(v => v === "b").length > 1 || 2) === true',
 			'a.find(val => key === "abc")',

--- a/test/packages/combinedPlugins.test.js
+++ b/test/packages/combinedPlugins.test.js
@@ -308,5 +308,60 @@ const { test } = QUnit;
 				},
 			}, assert);
 		});
+
+		([
+			'(() => (x + 1))',
+			'() => x + 1',
+			'() => (x + 1)',
+		]).forEach(expr => {
+			test(`should parse arrow body ${expr} same, whether parenthesized or not`, function (assert) {
+				testParser(			expr, {
+					type: 'ArrowFunctionExpression',
+					params: null,
+					body: {
+						type: 'BinaryExpression',
+						operator: '+',
+						left: {
+							type: 'Identifier',
+							name: 'x',
+						},
+						right: {
+							type: 'Literal',
+							value: 1,
+							raw: '1',
+						},
+					},
+				}, assert);
+			});
+		});
+
+		test('should parse ()-enclosed, nested arrow correctly', (assert) => {
+			testParser(			'x => (() => x + 1)', {
+				type: 'ArrowFunctionExpression',
+				params: [
+					{
+						type: 'Identifier',
+						name: 'x',
+					}
+				],
+				body: {
+					type: 'ArrowFunctionExpression',
+					params: null,
+					body: {
+						type: 'BinaryExpression',
+						operator: '+',
+						left: {
+							type: 'Identifier',
+							name: 'x',
+						},
+						right: {
+							type: 'Literal',
+							value: 1,
+							raw: '1',
+						},
+					},
+				},
+			}, assert);
+		});
 	});
 }());

--- a/test/packages/combinedPlugins.test.js
+++ b/test/packages/combinedPlugins.test.js
@@ -267,5 +267,46 @@ const { test } = QUnit;
 				callee: {},
 			}, assert);
 		});
+
+		test('should parse assignment to nested arrow function correctly', (assert) => {
+			testParser(			'f = x => y => x + y', {
+				type: 'AssignmentExpression',
+				operator: '=',
+				left: {
+					type: 'Identifier',
+					name: 'f',
+				},
+				right: {
+					type: 'ArrowFunctionExpression',
+					params: [
+						{
+							type: 'Identifier',
+							name: 'x',
+						}
+					],
+					body: {
+						type: 'ArrowFunctionExpression',
+						params: [
+							{
+								type: 'Identifier',
+								name: 'y',
+							}
+						],
+						body: {
+							type: 'BinaryExpression',
+							operator: '+',
+							left: {
+								type: 'Identifier',
+								name: 'x',
+							},
+							right: {
+								type: 'Identifier',
+								name: 'y',
+							},
+						},
+					},
+				},
+			}, assert);
+		});
 	});
 }());


### PR DESCRIPTION
- arrows now use the new right-associative option, just like assignment
- has to use a non-zero priority, or it will break out of the binary operator loop prematurely with multiple expressions
- arrow expression might not be at the root (or solely at the root) so traverse all sub-object nodes to convert from binary to arrow (i.e. assignment to arrow)
- correct arrow body should be parsed as expression instead of just token

fixes #204