### PR TITLE
New `numbers` plugin to expand allowable number formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,19 @@ JSEP supports defining custom hooks for extending or modifying the expression pa
 Plugins are registered by calling `jsep.plugins.register()` with the plugin(s) as the argument(s).
 
 #### JSEP-provided plugins:
-|                                      |                                                                                           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------- |
-| [ternary](packages/ternary)           | Built-in by default, adds support for ternary `a ? b : c` expressions                     |
-| [arrow](packages/arrow)               | Adds arrow-function support: `v => !!v`                                                   |
-| [assignment](packages/assignment)     | Adds assignment and update expression support: `a = 2`, `a++`                             |
-| [comment](packages/comment)           | Adds support for ignoring comments: `a /* ignore this */ > 1 // ignore this too`          |
-| [new](packages/new)                   | Adds 'new' keyword support: `new Date()`                                                  |
-| [object](packages/object)             | Adds object expression support: `{ a: 1, b: { c }}`                                       |
-| [regex](packages/regex)               | Adds support for regular expression literals: `/[a-z]{2}/ig`                              |
-| [spread](packages/spread)             | Adds support for the spread operator, `fn(...[1, ...a])`. Works with `object` plugin, too |
-| [template](packages/template)         | Adds template literal support: `` `hi ${name}` ``                                         |
-|                                      |                                                                                           |
+|                                   |                                                                                           |
+|-----------------------------------|-------------------------------------------------------------------------------------------|
+| [ternary](packages/ternary)       | Built-in by default, adds support for ternary `a ? b : c` expressions                     |
+| [arrow](packages/arrow)           | Adds arrow-function support: `v => !!v`                                                   |
+| [assignment](packages/assignment) | Adds assignment and update expression support: `a = 2`, `a++`                             |
+| [comment](packages/comment)       | Adds support for ignoring comments: `a /* ignore this */ > 1 // ignore this too`          |
+| [new](packages/new)               | Adds 'new' keyword support: `new Date()`                                                  |
+| [numbers](packages/numbers)       | Adds hex, octal, and binary number support, ignore _ char                                 |
+| [object](packages/object)         | Adds object expression support: `{ a: 1, b: { c }}`                                       |
+| [regex](packages/regex)           | Adds support for regular expression literals: `/[a-z]{2}/ig`                              |
+| [spread](packages/spread)         | Adds support for the spread operator, `fn(...[1, ...a])`. Works with `object` plugin, too |
+| [template](packages/template)     | Adds template literal support: `` `hi ${name}` ``                                         |
+|                                   |                                                                                           |
 
 #### How to add plugins:
 Plugins have a `name` property so that they can only be registered once.

--- a/packages/numbers/.npmignore
+++ b/packages/numbers/.npmignore
@@ -1,0 +1,7 @@
+*
+*/
+!package.json
+!LICENSE
+!README.md
+!dist/**/*
+!types/**/*

--- a/packages/numbers/README.md
+++ b/packages/numbers/README.md
@@ -1,0 +1,39 @@
+[npm]: https://img.shields.io/npm/v/@jsep-plugin/numbers
+[npm-url]: https://www.npmjs.com/package/@jsep-plugin/numbers
+[size]: https://packagephobia.now.sh/badge?p=@jsep-plugin/numbers
+[size-url]: https://packagephobia.now.sh/result?p=@jsep-plugin/numbers
+
+[![npm][npm]][npm-url]
+[![size][size]][size-url]
+
+# @jsep-plugin/numbers
+
+A JSEP plugin for adding support for additional number formats, hexadecimal, binary and octal.
+It also adds support to ignore _ characters in numbers 
+
+```javascript
+jsep('0xA'); // hexadecimal (10)  
+jsep('0b01001010'); // binary (74)
+jsep('0644'); // octal (420)
+jsep('0o644'); // octal (420)
+jsep('115_200'); // decimal (115200)
+```
+
+## Install
+
+```console
+npm install @jsep-plugin/numbers
+# or
+yarn add @jsep-plugin/numbers
+```
+
+## Usage
+```javascript
+import jsep from 'jsep';
+import jsepNumbers from '@jsep-plugin/numbers';
+jsep.plugins.register(jsepNumbers);
+```
+
+## Meta
+
+[LICENSE (MIT)](/LICENSE)

--- a/packages/numbers/package.json
+++ b/packages/numbers/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@jsep-plugin/numbers",
+	"version": "1.0.0",
+	"description": "Adds support for binary, hex, and octal number formats, including _",
+	"author": "Shelly (https://github.com/6utt3rfly)",
+	"maintainers": [
+		"Eric Smekens (https://github.com/EricSmekens)",
+		"Lea Verou (https://github.com/LeaVerou)",
+		"Shelly (https://github.com/6utt3rfly)"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"homepage": "https://ericsmekens.github.io/jsep/tree/master/packages/numbers#readme",
+	"license": "MIT",
+	"repository": {
+		"url": "EricSmekens/jsep",
+		"directory": "packages/numbers"
+	},
+	"type": "module",
+	"main": "./dist/cjs/index.cjs.js",
+	"module": "./dist/index.js",
+	"types": "types/tsd.d.ts",
+	"peerDependencies": {
+		"jsep": "^0.4.0||^1.0.0"
+	},
+	"devDependencies": {
+		"rollup": "^2.44.0",
+		"rollup-plugin-delete": "^2.0.0"
+	},
+	"engines": {
+		"node": ">= 10.16.0"
+	},
+	"scripts": {
+		"build": "rollup -c ../../plugin.rollup.config.js && cp ../../package-cjs.json dist/cjs/package.json",
+		"test": "cd ../../ && http-server -p 49649 --silent & node-qunit-puppeteer http://localhost:49649/packages/numbers/test/unit_tests.html",
+		"lint": "eslint src/**/*.js test/**/*.js"
+	}
+}

--- a/packages/numbers/src/index.js
+++ b/packages/numbers/src/index.js
@@ -1,0 +1,166 @@
+const NUM_0_CODE = 48;
+const UNDERSCORE = 95;
+
+export default {
+	name: 'numbers',
+
+	init(Jsep) {
+		Jsep.hooks.add('gobble-token', function gobbleNumber(env) {
+			if (this.code === NUM_0_CODE) {
+				const startIndex = this.index;
+				const numType = this.expr.charAt(this.index + 1);
+				const ranges = getNumberCodeRanges.call(this, numType);
+				if (!ranges) {
+					return;
+				}
+
+				let number = '';
+				while (isUnderscoreOrWithinRange(this.code, ranges)) {
+					if (this.code === UNDERSCORE) {
+						this.index ++;
+					}
+					else {
+						number += this.expr.charAt(this.index++);
+					}
+				}
+
+				// confirm valid syntax after building number string within ranges
+				if (Jsep.isIdentifierPart(this.code)) {
+					if (Jsep.isDecimalDigit(this.code) && Jsep.isDecimalDigit(numType.charCodeAt(0))) {
+						// abort octal processing and reset to ignore the leading 0
+						this.index = startIndex + 1;
+						gobbleBase10.call(this, env);
+						return;
+					}
+					this.throwError('unexpected char within number');
+				}
+
+				env.node = {
+					type: Jsep.LITERAL,
+					value: parseInt(number, getNumberBase(numType)),
+					raw: this.expr.substring(startIndex, this.index),
+				};
+			}
+			else if (Jsep.isDecimalDigit(this.code) || this.code === Jsep.PERIOD_CODE) {
+				gobbleBase10.call(this, env);
+			}
+		});
+
+		/**
+		 * Gets the range of allowable number codes (decimal) and updates index
+		 * @param {string} numType
+		 * @returns {number[][]|null}
+		 */
+		function getNumberCodeRanges(numType) {
+			if (numType === 'x' || numType === 'X') {
+				this.index += 2;
+				return [
+					[48, 57], // 0-9
+					[65, 70], // A-F
+					[97, 102], // a-f
+				];
+			}
+			else if (numType === 'b' || numType === 'B') {
+				this.index += 2;
+				return [[48, 49]]; // 0-1
+			}
+			else if (numType === 'o' || numType === 'O' ||
+				(numType >= '0' && numType <= '7')) { // 0-7 allows non-standard 0644 = 420
+				this.index += numType <= '7' ? 1 : 2;
+				return [[48, 55]]; // 0-7
+			}
+			return null;
+		}
+
+		/**
+		 * Supports Hex, Octal and Binary only
+		 * @param {string} numType
+		 * @returns {16|8|2}
+		 */
+		function getNumberBase(numType) {
+			if (numType === 'x' || numType === 'X') {
+				return 16;
+			}
+			else if (numType === 'b' || numType === 'B') {
+				return 2;
+			}
+			// default (includes non-stand 044)
+			return 8;
+		}
+
+		/**
+		 * Verifies number code is within given ranges
+		 * @param {number} code
+		 * @param {number[][]} ranges
+		 */
+		function isUnderscoreOrWithinRange(code, ranges) {
+			return code === UNDERSCORE ||
+				ranges.some(([min, max]) => code >= min && code <= max);
+		}
+
+		/**
+		 * Same as core gobbleNumericLiteral, but allows for _ char
+		 * @param {{ context?: typeof Jsep, node?: Expression }} env
+		 */
+		function gobbleBase10(env) {
+			const startIndex = this.index;
+			let number = '';
+
+			const gobbleDigits = () => {
+				while (Jsep.isDecimalDigit(this.code) || this.code === UNDERSCORE) {
+					if (this.code === UNDERSCORE) {
+						this.index++;
+					}
+					else {
+						number += this.expr.charAt(this.index++);
+					}
+				}
+			};
+
+			gobbleDigits();
+			if (this.code === Jsep.PERIOD_CODE) { // can start with a decimal marker
+				number += this.expr.charAt(this.index++);
+
+				gobbleDigits();
+			}
+
+			let ch = this.char;
+			if (ch === 'e' || ch === 'E') { // exponent marker
+				number += this.expr.charAt(this.index++);
+				ch = this.char;
+
+				if (ch === '+' || ch === '-') { // exponent sign
+					number += this.expr.charAt(this.index++);
+				}
+
+				gobbleDigits(); // exponent itself
+
+				if (!Jsep.isDecimalDigit(this.expr.charCodeAt(this.index - 1)) ) {
+					this.throwError('Expected exponent (' + number + this.char + ')');
+				}
+			}
+
+			const chCode = this.code;
+
+			// Check to make sure this isn't a variable name that start with a number (123abc)
+			if (Jsep.isIdentifierStart(chCode)) {
+				this.throwError('Variable names cannot start with a number (' +
+					number + this.char + ')');
+			}
+			else if (chCode === Jsep.PERIOD_CODE) {
+				if (number.length > 1) {
+					this.throwError(`Unexpected period ${JSON.stringify({ chCode, number }, null, 2)}`);
+				}
+				// leave other error-handling to jsep core. Also allows spread operator.
+				this.index = startIndex;
+				return;
+			}
+
+			env.node = {
+				type: Jsep.LITERAL,
+				value: parseFloat(number),
+				raw: this.expr.substring(startIndex, this.index),
+			};
+		}
+	}
+};

--- a/packages/numbers/test/index.test.js
+++ b/packages/numbers/test/index.test.js
@@ -1,0 +1,54 @@
+import jsep from '../../../src/index.js';
+import jsepNumbers from '../src/index.js';
+import { testParser, resetJsepDefaults } from '../../../test/test_utils.js';
+
+const { test } = QUnit;
+
+(function () {
+	QUnit.module('Plugin:Numbers', (qunit) => {
+		qunit.before(() => jsep.plugins.register(jsepNumbers));
+		qunit.after(resetJsepDefaults);
+
+		[
+			['0xA', 10],
+			['0xfF', 255],
+			['0xA_a', 170],
+			['0b01010101', 85],
+			['0b0000_0111', 7],
+			['0b1000_0000__0000_0000__0000_0000__0000_0000', 2147483648],
+			['0755', 493],
+			['0o644', 420],
+			['0795', 795], // aborts octal, reverts to decimal
+			['115_200', 115200],
+			['10_000E1', 10000E1],
+			['1_0E2_0', 10E20],
+			['1_0E+2_0', 10E20],
+			['1E-2', 1e-2],
+			['1_234.567_89', 1234.56789],
+			['0.1', 0.1],
+			['.1', .1],
+		].forEach(([expr, value]) => test(`should parse the value correctly ${expr}`, (assert) => {
+			testParser(expr, { value }, assert);
+		}));
+
+		[
+			'0b12abc',
+			'123abc',
+			'1_2_abc',
+			'0755a',
+			'0x1Z',
+			'12_34.56.78',
+			'ab_cd.123',
+			'1_2E3.4',
+		].forEach(expr => test(`should give an error for invalid expression ${expr}`, (assert) => {
+			assert.throws(() => jsep(expr));
+		}));
+
+		[
+			'_123',
+			'_0b123',
+		].forEach((expr) => test(`should still parse identifier correctly ${expr}`, (assert) => {
+			testParser(expr, { type: 'Identifier', name: expr }, assert);
+		}));
+	});
+}());

--- a/packages/numbers/test/unit_tests.html
+++ b/packages/numbers/test/unit_tests.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<title>Plugin Tests</title>
+		<base href="../../../">
+		<script src="./test/resources/qunit-2.10.0.js"></script>
+		<link rel=StyleSheet href="./test/resources/qunit-2.10.0.css" type="text/css" media=screen />
+
+		<script src="./test/resources/esprima.js"></script>
+		<script type="module" src="./packages/numbers/test/index.test.js"></script>
+	</head>
+
+	<body>
+		<h1 id="qunit-header">Plugin-Numbers Unit Tests</h1>
+		<h2 id="qunit-banner"></h2>
+		<div id="qunit-testrunner-toolbar"></div>
+		<h2 id="qunit-userAgent"></h2>
+		<ol id="qunit-tests"></ol>
+	</body>
+</html>

--- a/packages/numbers/types/tsd.d.ts
+++ b/packages/numbers/types/tsd.d.ts
@@ -1,0 +1,3 @@
+import * as jsep from 'jsep';
+export const name: string;
+export function init(this: typeof jsep): void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,14 @@ importers:
       rollup: 2.55.1
       rollup-plugin-delete: 2.0.0
 
+  packages/numbers:
+    specifiers:
+      rollup: ^2.44.0
+      rollup-plugin-delete: ^2.0.0
+    devDependencies:
+      rollup: 2.55.1
+      rollup-plugin-delete: 2.0.0
+
   packages/object:
     specifiers:
       rollup: ^2.44.0

--- a/test/packages/combinedPlugins.test.js
+++ b/test/packages/combinedPlugins.test.js
@@ -4,6 +4,7 @@ import jsepAssignment from '../../packages/assignment/src/index.js';
 import jsepAsyncAwait from '../../packages/async-await/src/index.js';
 import jsepComment from '../../packages/comment/src/index.js';
 import jsepNew from '../../packages/new/src/index.js';
+import jsepNumbers from '../../packages/numbers/src/index.js';
 import jsepObject from '../../packages/object/src/index.js';
 import jsepRegex from '../../packages/regex/src/index.js';
 import jsepSpread from '../../packages/spread/src/index.js';
@@ -22,6 +23,7 @@ const { test } = QUnit;
 				jsepAsyncAwait,
 				jsepComment,
 				jsepNew,
+				jsepNumbers,
 				jsepObject,
 				jsepRegex,
 				jsepSpread,
@@ -74,6 +76,26 @@ const { test } = QUnit;
 			'[new A(), new A()]',
 			'new A("1")',
 			'new A(1, 2)',
+
+			// numbers plugin:
+			'0xA',
+			'0xfF',
+			'0xA_a',
+			'0b01010101',
+			'0b0000_0111',
+			'0b1000_0000__0000_0000__0000_0000__0000_0000',
+			'0755',
+			'0o644',
+			'0795',
+			'115_200',
+			'10_000E1',
+			'1_0E2_0',
+			'1_0E+2_0',
+			'1E-2',
+			'1_234.567_89',
+			'0.1',
+			'.1',
+
 			'({ a: 1, b: 2 })',
 			'{ [key || key2]: { a: 0 } }',
 			'{ a: { b: { c: 1 } } }',

--- a/test/tests.js
+++ b/test/tests.js
@@ -8,6 +8,7 @@ export * from '../packages/async-await/test/index.test.js';
 export * from '../packages/ternary/test/index.test.js';
 export * from '../packages/comment/test/index.test.js';
 export * from '../packages/new/test/index.test.js';
+export * from '../packages/numbers/test/index.test.js';
 export * from '../packages/object/test/index.test.js';
 export * from '../packages/regex/test/index.test.js';
 export * from '../packages/spread/test/index.test.js';


### PR DESCRIPTION
supports:
- hex (0x123)
- binary(0b1111)
- octal (0o644 and 0644)

Also adds ignoring of underscore `_` characters, which means basically copying/replacing the core `gobbleNumericLiteral` method. Didn't add BigInt support because I felt that it would be better as a separate plugin, so it can also add operators, and for not limiting this plugin's compatibility since BigInt is newer 🤷🏻‍♀️ 

fixes #206