### PR TITLE
fix: handle charsets and escaped / within regex

### DIFF
--- a/packages/regex/src/index.js
+++ b/packages/regex/src/index.js
@@ -1,4 +1,5 @@
 const FSLASH_CODE = 47; // '/'
+const BSLASH_CODE = 92; // '\\'
 
 export default {
 	name: 'regex',
@@ -9,8 +10,9 @@ export default {
 			if (this.code === FSLASH_CODE) {
 				const patternIndex = ++this.index;
 
+				let inCharSet = false;
 				while (this.index < this.expr.length) {
-					if (this.char === '/') {
+					if (this.code === FSLASH_CODE && !inCharSet) {
 						const pattern = this.expr.slice(patternIndex, this.index);
 
 						let flags = '';
@@ -44,7 +46,13 @@ export default {
 						env.node = this.gobbleTokenProperty(env.node);
 						return env.node;
 					}
-					this.index += 1;
+					if (this.code === jsep.OBRACK_CODE) {
+						inCharSet = true;
+					}
+					else if (inCharSet && this.code === jsep.CBRACK_CODE) {
+						inCharSet = false;
+					}
+					this.index += this.code === BSLASH_CODE ? 2 : 1;
 				}
 				this.throwError('Unclosed Regex');
 			}


### PR DESCRIPTION
putting a / in a char set [] will no longer abort the regex early
putting an escaped / will no longer abort the regex early

fixes #214