### PR TITLE
fix: embed correct version into builds

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           version: 6.0.2
           run_install: true
-      - run: pnpm install
+      - run: pnpm install --ignore-scripts
       - run: pnpm run default
       - run: pnpm run release
         env:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/6utt3rfly/jsep"
+		"url": "https://github.com/EricSmekens/jsep.git"
 	},
 	"type": "module",
 	"main": "./dist/cjs/jsep.cjs.js",
@@ -117,8 +117,13 @@
 			[
 				"@semantic-release/npm",
 				{
-					"npmPublish": false,
 					"tarballDir": "./"
+				}
+			],
+			[
+				"@semantic-release/git",
+				{
+					"prepareCmd": "NEXT_VERSION=${nextRelease.version} pnpm run build"
 				}
 			],
 			[

--- a/packages/arrow/src/index.js
+++ b/packages/arrow/src/index.js
@@ -1,11 +1,7 @@
 const ARROW_EXP = 'ArrowFunctionExpression';
 
-// test arrow change
-
 export default {
 	name: 'arrow',
-
-	version: '<%= version %>',
 
 	init(jsep) {
 		// arrow-function expressions: () => x, v => v, (a, b) => v

--- a/packages/ternary/src/index.js
+++ b/packages/ternary/src/index.js
@@ -1,7 +1,5 @@
 const CONDITIONAL_EXP = 'ConditionalExpression';
 
-// test change
-
 export default {
 	name: 'ternary',
 

--- a/release.sh
+++ b/release.sh
@@ -5,10 +5,10 @@
 # (or npm run release -- --debug --no-cli --dry-run)
 
 echo "Semantic-Release JSEP"
-pnpx semantic-release "$@" --no-ci
+pnpx semantic-release "$@"
 
 packages=($(ls -d packages/*))
 for package in "${packages[@]}"; do
   printf "\n\nSemantic-Release $package\n"
-  (cd $package && pwd && pnpx semantic-release --no-ci -e semantic-release-monorepo "$@")
+  (cd $package && pwd && pnpx semantic-release -e semantic-release-monorepo "$@")
 done


### PR DESCRIPTION
- adds NEXT_VERSION env variable to the rollup
- builds the package as part of semantic-release so that it can utilize the new version in the build
- commit to git after npm so that git contains the updated package.json file

fixes #216

NOTE: @EricSmekens - so sorry that I thought I was testing the release on my fork, but then found that they were pushing here 😬 !! This PR reverts those (harmless) commits as well.