### PR TITLE
remove npm workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
 	},
 	"typings": "typings/tsd.d.ts",
 	"private": false,
-	"workspaces": [
-		"./packages/*"
-	],
 	"devDependencies": {
 		"@commitlint/cli": "^13.1.0",
 		"@commitlint/config-angular": "^13.1.0",


### PR DESCRIPTION
remove npm "workspaces". pnpm uses `pnpm-workspace.yaml` instead.

yarn: "warning Workspaces can only be enabled in private projects"

fixes #218