### PR TITLE
Add "types" to package.json "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	"exports": {
 		".": {
 			"require": "./dist/cjs/jsep.cjs.js",
-			"default": "./dist/jsep.js"
+			"default": "./dist/jsep.js",
+			"types": "typings/tsd.d.ts"
 		}
 	},
 	"typings": "typings/tsd.d.ts",


### PR DESCRIPTION
The "exports" property has precedence over "typings", thus Typescript 4.7+ doesn't recognise the types.

Adding "types" in "exports" solve the issue.