### PR TITLE
fix: support TypeScript's Node16 resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"module": "./dist/jsep.js",
 	"exports": {
 		".": {
-			"types": "typings/tsd.d.ts",
+			"types": "./typings/tsd.d.ts",
 			"require": "./dist/cjs/jsep.cjs.js",
 			"default": "./dist/jsep.js"
 		}


### PR DESCRIPTION
We have a node project which uses TypeScript's `Node16` module resolution (https://www.typescriptlang.org/docs/handbook/esm-node.html).

In this configuration, TypeScript is unable to find the type definition files that are bundled in this library.

After debugging it on my end it looks like the problem was simply that the `types` declaration didn't follow Node's exports syntax

![image](https://user-images.githubusercontent.com/1280915/205053966-c5b0a832-5524-49f0-8c4c-c7ce4d063a0c.png)
