### PR TITLE
fix: add type definitions for literal methods

### DIFF
--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -153,6 +153,12 @@ declare module 'jsep' {
 
 		function removeIdentifierChar(identifierName: string): void;
 
+		function addLiteral(literalName: string, literalValue: string): void;
+
+		function removeLiteral(literalName: string): void;
+
+		function removeAllLiteral(): void;
+
 		const version: string;
 	}
 

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -153,11 +153,11 @@ declare module 'jsep' {
 
 		function removeIdentifierChar(identifierName: string): void;
 
-		function addLiteral(literalName: string, literalValue: string): void;
+		function addLiteral(literalName: string, literalValue: any): void;
 
 		function removeLiteral(literalName: string): void;
 
-		function removeAllLiteral(): void;
+		function removeAllLiterals(): void;
 
 		const version: string;
 	}


### PR DESCRIPTION
I've added missing methods to `typings/tsd.d.ts` for better Typescript support.