### PR TITLE
Do not access prototype, callee, caller & arguments properties

### DIFF
--- a/src/jsep.js
+++ b/src/jsep.js
@@ -966,7 +966,7 @@ const jsep = expr => (new Jsep(expr)).parse();
 const staticMethods = Object.getOwnPropertyNames(Jsep);
 staticMethods
 	.forEach((m) => {
-		if (jsep[m] === undefined && m !== 'prototype') {
+		if (m !== 'prototype' && m !== 'caller' && m !== 'callee' && m !== 'arguments' && jsep[m] === undefined) {
 			jsep[m] = Jsep[m];
 		}
 	});


### PR DESCRIPTION
Im tried to use this library in react-native with Hermes JS engine enabled, and got errors.
Trying to access `caller`, `callee`, `arguments` properties retults to TypeError: Restricted in strict mode

Related links:
https://github.com/facebook/react-native/issues/34868
https://github.com/axios/axios/issues/4998#issuecomment-1268162199
https://github.com/axios/axios/issues/5231
https://github.com/axios/axios/pull/5152