### PR TITLE
fix: update Array elements typing

### DIFF
--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -9,7 +9,8 @@ declare module 'jsep' {
 
 		export interface ArrayExpression extends Expression {
 			type: 'ArrayExpression';
-			elements: Expression[];
+			/** The expression can be null in the case of array holes ([ , , ]) */
+			elements: Array<null | Expression>;
 		}
 
 		export interface BinaryExpression extends Expression {


### PR DESCRIPTION
According to this line: https://github.com/EricSmekens/jsep/blob/553833504f2f204964a7d63680da5c8b6471d3ad/src/jsep.js#LL807C24-L807C24, the elements array on array expressions can include null. It has been our experience when parsing an array with holes (`[,,,]`)

This PR updates the typing of `ArrayExpression.elements` to include null