### PR TITLE
Fix throwError return type

### DIFF
--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -110,7 +110,7 @@ declare module 'jsep' {
 			gobbleArguments: (untilICode: number) => PossibleExpression;
 			gobbleGroup: () => Expression;
 			gobbleArray: () => PossibleExpression;
-			throwError: (msg: string) => void;
+			throwError: (msg: string) => never;
 		}
 
 		export type HookType = 'gobble-expression' | 'after-expression' | 'gobble-token' | 'after-token' | 'gobble-spaces';


### PR DESCRIPTION
So compiler can infer types correctly if throwError is used inside an if statement