### PR TITLE
fix: support member exp before tagged template (String.raw)

### DIFF
--- a/packages/template/src/index.js
+++ b/packages/template/src/index.js
@@ -77,7 +77,7 @@ export default {
 		jsep.hooks.add('gobble-token', gobbleTemplateLiteral);
 
 		jsep.hooks.add('after-token', function gobbleTaggedTemplateIdentifier(env) {
-			if (env.node.type === jsep.IDENTIFIER && this.code === BTICK_CODE) {
+			if ((env.node.type === jsep.IDENTIFIER || env.node.type === jsep.MEMBER_EXP) && this.code === BTICK_CODE) {
 				env.node = {
 					type: TAGGED_TEMPLATE_EXPRESSION,
 					tag: env.node,

--- a/packages/template/test/index.test.js
+++ b/packages/template/test/index.test.js
@@ -118,6 +118,93 @@ const { test } = QUnit;
 			}, assert);
 		});
 
+		test('should parse String.raw tagged, nested template literal expression', (assert) => {
+			testParser('String.raw`token ${`nested ${`deeply` + "str"} blah`}`', {
+				type: 'TaggedTemplateExpression',
+				tag: {
+					type: "MemberExpression",
+					computed: false,
+					object: {
+						type: "Identifier",
+						name: "String"
+					},
+					property: {
+						type: "Identifier",
+						name:"raw"
+					}
+				},
+				quasi: {
+					type: 'TemplateLiteral',
+					quasis: [
+						{
+							type: 'TemplateElement',
+							value: {
+								raw: 'token ',
+								cooked: 'token ',
+							},
+							tail: false,
+						},
+						{
+							type: 'TemplateElement',
+							value: {
+								raw: '',
+								cooked: '',
+							},
+							tail: true,
+						},
+					],
+					expressions: [
+						{
+							type: 'TemplateLiteral',
+							quasis: [
+								{
+									type: 'TemplateElement',
+									value: {
+										raw: 'nested ',
+										cooked: 'nested ',
+									},
+									tail: false,
+								},
+								{
+									type: 'TemplateElement',
+									value: {
+										raw: ' blah',
+										cooked: ' blah',
+									},
+									tail: true,
+								},
+							],
+							expressions: [
+								{
+									type: 'BinaryExpression',
+									operator: '+',
+									left: {
+										type: 'TemplateLiteral',
+										quasis: [
+											{
+												type: 'TemplateElement',
+												value: {
+													raw: 'deeply',
+													cooked: 'deeply',
+												},
+												tail: true,
+											},
+										],
+										expressions: [],
+									},
+									right: {
+										type: 'Literal',
+										value: 'str',
+										raw: '"str"',
+									},
+								},
+							],
+						},
+					],
+				},
+			}, assert);
+		});		
+
 		test('should parse multiple vars within template literal expression', (assert) => {
 			testParser('`hi ${last}, ${first} ${middle}!`', {
 				type: 'TemplateLiteral',


### PR DESCRIPTION
To support e.g. `String.raw` tagged template the template plugin needs to also consider member expressions for template tags. 