### PR TITLE
Update typings for TypeScript 5.6

### DIFF
--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,6 +1,4 @@
 declare module 'jsep' {
-
-	namespace jsep {
 		export type baseTypes = string | number | boolean | RegExp | null | undefined | object;
 		export interface Expression {
 			type: string;
@@ -172,9 +170,6 @@ declare module 'jsep' {
 		function removeAllLiterals(): void;
 
 		const version: string;
-	}
-
-	function jsep(val: string | jsep.Expression): jsep.Expression;
-
-	export = jsep;
 }
+
+export default function jsep(val: string | Expression): Expression;


### PR DESCRIPTION
Fixes:
```
../../node_modules/jsep/typings/tsd.d.ts(179,2): error TS1203: 
Export assignment cannot be used when targeting ECMAScript 
modules. Consider using 'export default' or another module 
format instead.
```