### PR TITLE
feat: Allow `..` (and `...`) as an operator in Jsep parser.

### DIFF
--- a/packages/numbers/src/index.js
+++ b/packages/numbers/src/index.js
@@ -41,9 +41,8 @@ export default {
 					raw: this.expr.substring(startIndex, this.index),
 				};
 			}
-			else if (Jsep.isDecimalDigit(this.code) || (
-					 this.code === Jsep.PERIOD_CODE &&  this.expr.charCodeAt(this.index +1) !== Jsep.PERIOD_CODE
-				 )) {
+			else {
+				// this will return `undefined` if it's not a number
 				gobbleBase10.call(this, env);
 			}
 		});
@@ -108,6 +107,12 @@ export default {
 			const startIndex = this.index;
 			let number = '';
 
+			if (!Jsep.isDecimalDigit(this.code) && !(
+				this.code === Jsep.PERIOD_CODE &&  this.expr.charCodeAt(this.index +1) !== Jsep.PERIOD_CODE
+			)) {
+				return;
+			}
+			
 			const gobbleDigits = () => {
 				while (Jsep.isDecimalDigit(this.code) || this.code === UNDERSCORE) {
 					if (this.code === UNDERSCORE) {
@@ -143,7 +148,7 @@ export default {
 			}
 
 			const chCode = this.code;
-			const prevCode = this.expr.charCodeAt(this.index - 1)
+			const prevCode = this.expr.charCodeAt(this.index - 1);
 
 			// Check to make sure this isn't a variable name that start with a number (123abc)
 			if (Jsep.isIdentifierStart(chCode)) {
@@ -151,8 +156,8 @@ export default {
 					number + this.char + ')');
 			}
 			else if (chCode === Jsep.PERIOD_CODE && prevCode ===  Jsep.PERIOD_CODE) {
-				// two `..` with at least one digit already processed (otherwise gobbleBase10 wouldn't have been called)
-				// rollback index and let Jsep see if it's an operator...
+				// number "ends" with '..', treat it as the start of a new operator, and roll back the index.
+				// note that the possibility of `..` as the first two chars is eliminated above
 				this.index --;
 			}
 			else if (number.length === 1 && number.charCodeAt(0) === Jsep.PERIOD_CODE) {

--- a/packages/numbers/src/index.js
+++ b/packages/numbers/src/index.js
@@ -41,7 +41,9 @@ export default {
 					raw: this.expr.substring(startIndex, this.index),
 				};
 			}
-			else if (Jsep.isDecimalDigit(this.code) || this.code === Jsep.PERIOD_CODE) {
+			else if (Jsep.isDecimalDigit(this.code) || (
+					 this.code === Jsep.PERIOD_CODE &&  this.expr.charCodeAt(this.index +1) !== Jsep.PERIOD_CODE
+				 )) {
 				gobbleBase10.call(this, env);
 			}
 		});
@@ -141,19 +143,20 @@ export default {
 			}
 
 			const chCode = this.code;
+			const prevCode = this.expr.charCodeAt(this.index - 1)
 
 			// Check to make sure this isn't a variable name that start with a number (123abc)
 			if (Jsep.isIdentifierStart(chCode)) {
 				this.throwError('Variable names cannot start with a number (' +
 					number + this.char + ')');
 			}
-			else if (chCode === Jsep.PERIOD_CODE) {
-				if (number.length > 1) {
-					this.throwError(`Unexpected period ${JSON.stringify({ chCode, number }, null, 2)}`);
-				}
-				// leave other error-handling to jsep core. Also allows spread operator.
-				this.index = startIndex;
-				return;
+			else if (chCode === Jsep.PERIOD_CODE && prevCode ===  Jsep.PERIOD_CODE) {
+				// two `..` with at least one digit already processed (otherwise gobbleBase10 wouldn't have been called)
+				// rollback index and let Jsep see if it's an operator...
+				this.index --;
+			}
+			else if (number.length === 1 && number.charCodeAt(0) === Jsep.PERIOD_CODE) {
+				this.throwError('Unexpected period');
 			}
 
 			env.node = {

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -481,7 +481,7 @@ export class Jsep {
 	 * @returns {boolean|jsep.Expression}
 	 */
 	gobbleToken() {
-		let ch, to_check, tc_len, node;
+		let ch, ch_next, to_check, tc_len, node;
 
 		this.gobbleSpaces();
 		node = this.searchHook('gobble-token');
@@ -490,9 +490,10 @@ export class Jsep {
 		}
 
 		ch = this.code;
+		ch_next = this.expr.charCodeAt(this.index +1);
 
-		if (Jsep.isDecimalDigit(ch) || ch === Jsep.PERIOD_CODE) {
-			// Char code 46 is a dot `.` which can start off a numeric literal
+		if (Jsep.isDecimalDigit(ch) || (ch === Jsep.PERIOD_CODE && ch_next !== Jsep.PERIOD_CODE)) {
+			// A PERIOD `.` can start off a numeric literal, but not if it's `..` (which can be an operator)
 			return this.gobbleNumericLiteral();
 		}
 
@@ -612,8 +613,8 @@ export class Jsep {
 					this.index--;
 				}
 				else if (this.expr.charCodeAt(this.index) === Jsep.PERIOD_CODE) {
-					// allow '..' as an operator (note that we already advanced this.index, above)
-					this.index -= 2;
+					// if '..' it's not a property extractor, so exit after reverting this.index, which we advanced, above
+					this.index--;
 					break;
 				}
 				this.gobbleSpaces();
@@ -676,13 +677,19 @@ export class Jsep {
 		}
 
 		chCode = this.code;
+		const prevCode = this.expr.charCodeAt(this.index - 1)
 
 		// Check to make sure this isn't a variable name that start with a number (123abc)
 		if (Jsep.isIdentifierStart(chCode)) {
 			this.throwError('Variable names cannot start with a number (' +
 				number + this.char + ')');
 		}
-		else if (chCode === Jsep.PERIOD_CODE || (number.length === 1 && number.charCodeAt(0) === Jsep.PERIOD_CODE)) {
+		else if (chCode === Jsep.PERIOD_CODE && prevCode ===  Jsep.PERIOD_CODE) {
+			// number "ends" with '..', treat it as the start of a new operator, and roll back the index.
+			// note that the call to gobbleNumbericLiteral() prevents the possibility of "number" starting with `..`
+			this.index--;
+		}
+		else if (number.length === 1 && number.charCodeAt(0) === Jsep.PERIOD_CODE) {
 			this.throwError('Unexpected period');
 		}
 

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -610,7 +610,8 @@ export class Jsep {
 			else if (ch === Jsep.PERIOD_CODE || optional) {
 				if (optional) {
 					this.index--;
-				} else if (this.expr.charCodeAt(this.index) === Jsep.PERIOD_CODE) {
+				}
+				else if (this.expr.charCodeAt(this.index) === Jsep.PERIOD_CODE) {
 					// allow '..' as an operator (note that we already advanced this.index, above)
 					this.index -= 2;
 					break;

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -481,22 +481,18 @@ export class Jsep {
 	 * @returns {boolean|jsep.Expression}
 	 */
 	gobbleToken() {
-		let ch, ch_next, to_check, tc_len, node;
+		let ch, to_check, tc_len, node;
 
 		this.gobbleSpaces();
 		node = this.searchHook('gobble-token');
+		if (!node) {
+			node = this.gobbleNumericLiteral();
+		}
 		if (node) {
 			return this.runHook('after-token', node);
 		}
 
 		ch = this.code;
-		ch_next = this.expr.charCodeAt(this.index +1);
-
-		if (Jsep.isDecimalDigit(ch) || (ch === Jsep.PERIOD_CODE && ch_next !== Jsep.PERIOD_CODE)) {
-			// A PERIOD `.` can start off a numeric literal, but not if it's `..` (which can be an operator)
-			return this.gobbleNumericLiteral();
-		}
-
 		if (ch === Jsep.SQUOTE_CODE || ch === Jsep.DQUOTE_CODE) {
 			// Single or double quotes
 			node = this.gobbleStringLiteral();
@@ -638,12 +634,19 @@ export class Jsep {
 	}
 
 	/**
-	 * Parse simple numeric literals: `12`, `3.4`, `.5`. Do this by using a string to
+	 * Check for and parse simple numeric literals: `12`, `3.4`, `.5`. Do this by using a string to
 	 * keep track of everything in the numeric literal and then calling `parseFloat` on that string
-	 * @returns {jsep.Literal}
+	 * @returns {jsep.Literal|undefined}
 	 */
 	gobbleNumericLiteral() {
-		let number = '', ch, chCode;
+		let number = '', ch, ch_next, chCode;
+		chCode = this.code;
+		ch_next = this.expr.charCodeAt(this.index +1);
+
+		if (!Jsep.isDecimalDigit(chCode) && !(chCode === Jsep.PERIOD_CODE && ch_next !== Jsep.PERIOD_CODE)) {
+			// A PERIOD `.` can start off a numeric literal, but not if it's `..` (which can be an operator)
+			return;
+		}
 
 		while (Jsep.isDecimalDigit(this.code)) {
 			number += this.expr.charAt(this.index++);
@@ -677,7 +680,7 @@ export class Jsep {
 		}
 
 		chCode = this.code;
-		const prevCode = this.expr.charCodeAt(this.index - 1)
+		const prevCode = this.expr.charCodeAt(this.index - 1);
 
 		// Check to make sure this isn't a variable name that start with a number (123abc)
 		if (Jsep.isIdentifierStart(chCode)) {
@@ -686,7 +689,7 @@ export class Jsep {
 		}
 		else if (chCode === Jsep.PERIOD_CODE && prevCode ===  Jsep.PERIOD_CODE) {
 			// number "ends" with '..', treat it as the start of a new operator, and roll back the index.
-			// note that the call to gobbleNumbericLiteral() prevents the possibility of "number" starting with `..`
+			// note that the possibility of `..` as the first two chars is eliminated above
 			this.index--;
 		}
 		else if (number.length === 1 && number.charCodeAt(0) === Jsep.PERIOD_CODE) {

--- a/src/jsep.js
+++ b/src/jsep.js
@@ -610,6 +610,10 @@ export class Jsep {
 			else if (ch === Jsep.PERIOD_CODE || optional) {
 				if (optional) {
 					this.index--;
+				} else if (this.expr.charCodeAt(this.index) === Jsep.PERIOD_CODE) {
+					// allow '..' as an operator (note that we already advanced this.index, above)
+					this.index -= 2;
+					break;
 				}
 				this.gobbleSpaces();
 				node = {


### PR DESCRIPTION
feat: Allow `..` (and `...`) as an operator in Jsep parser.

Resolves #274 (which I also want resolved for a feature we are considering in Bitfocus Companion).
